### PR TITLE
Feat:"사장님 정보 관리" 모달 UI 구현

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,8 +33,8 @@ export default function RootLayout({
       <body>
         <Sidebar />
         <Header />
-        {children}
         <ModalManager />
+        {children}
       </body>
     </html>
   );

--- a/src/app/modaltest/page.tsx
+++ b/src/app/modaltest/page.tsx
@@ -38,6 +38,11 @@ const ModalPage = () => {
           내 정보 수정
         </button>
       </div>
+      <div>
+        <button onClick={() => openModal("ChangeCEOInfoModal")}>
+          사장님 정보 관리
+        </button>
+      </div>
     </div>
   );
 };

--- a/src/components/modal/modalContainer/ModalContainer.tsx
+++ b/src/components/modal/modalContainer/ModalContainer.tsx
@@ -31,21 +31,24 @@ const ModalContainer = ({ children }: { children: ReactNode }) => {
     <div className="fixed inset-0 z-10 flex items-end justify-center bg-black/50 pc:items-center tablet:items-center">
       <div
         ref={modalRef}
-        className="relative rounded-[24px] rounded-b-none bg-gray-50 px-[24px] pb-[16px] pt-[24px] pc:rounded-[24px] pc:px-[80px] pc:pb-[24px] pc:pt-[32px] tablet:rounded-[24px]"
+        className="relative rounded-[24px] rounded-b-none bg-gray-50 px-[24px] pb-[16px] pt-[24px] pc:rounded-[24px] pc:px-10 pc:pb-[24px] pc:pt-[32px] tablet:rounded-[24px]"
       >
-        {children}
-        <button
-          onClick={() => closeModal()}
-          className="absolute right-[16px] top-[16px] pc:right-[24px] pc:top-[24px]"
-        >
-          <Image
-            src="/icon/close-lg.svg"
-            width={36}
-            height={36}
-            alt="닫기"
-            className="h-auto w-[24px] pc:w-[36px]"
-          />
-        </button>
+        <div className="scrollbar-hidden max-h-[90vh] overflow-y-auto">
+          {children}
+
+          <button
+            onClick={() => closeModal()}
+            className="absolute right-[16px] top-[16px] pc:right-[24px] pc:top-[24px]"
+          >
+            <Image
+              src="/icon/close-lg.svg"
+              width={36}
+              height={36}
+              alt="닫기"
+              className="h-auto w-[24px] pc:w-[36px]"
+            />
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/components/modal/modalContent/ChangeCEOInfoModal.tsx
+++ b/src/components/modal/modalContent/ChangeCEOInfoModal.tsx
@@ -1,5 +1,164 @@
+"use client";
+
+import Image from "next/image";
+import ModalContainer from "../modalContainer/ModalContainer";
+import FormInput from "@/components/input/FormInput";
+import ErrorText from "@/components/errorText/ErrorText";
+import { useState } from "react";
+import { useForm, Path } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { changeCEOInfoSchema } from "@/schema/modal/changeCEOInfoSchema";
+
 const ChangeCEOInfoModal = () => {
-  return <div>사장님 정보 관리</div>;
+  const [previewSrc, setPreviewSrc] = useState("");
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid, isSubmitting },
+  } = useForm<z.infer<typeof changeCEOInfoSchema>>({
+    resolver: zodResolver(changeCEOInfoSchema),
+    mode: "onChange",
+    defaultValues: {
+      nickname: "",
+      storeName: "",
+      storePhoneNumber: "",
+      phoneNumber: "",
+      location: "",
+    },
+  });
+
+  const inputArr = [
+    {
+      label: "닉네임",
+      name: "nickname",
+      type: "text",
+      placeholder: "닉네임을 입력해주세요.",
+      error: errors.nickname,
+      register: register("nickname"),
+      required: true,
+    },
+    {
+      label: "가게 이름",
+      name: "storeName",
+      type: "text",
+      placeholder: "가게 이름(상호명)을 입력해주세요.",
+      error: errors.storeName,
+      register: register("storeName"),
+      required: true,
+    },
+    {
+      label: "가게 전화번호",
+      name: "storePhoneNumber",
+      type: "tel",
+      placeholder: "숫자만 입력해주세요.",
+      error: errors.storePhoneNumber,
+      register: register("storePhoneNumber"),
+      required: true,
+    },
+    {
+      label: "사장님 전화번호",
+      name: "phoneNumber",
+      type: "tel",
+      placeholder: "숫자만 입력해주세요.",
+      error: errors.phoneNumber,
+      register: register("phoneNumber"),
+      required: false,
+    },
+    {
+      label: "가게 위치",
+      name: "location",
+      type: "text",
+      placeholder: "위치를 입력해주세요.",
+      error: errors.location,
+      register: register("location"),
+      required: true,
+    },
+  ];
+
+  const onSubmit = () => {
+    // 기능 구현 필요
+  };
+
+  return (
+    <ModalContainer>
+      <div className="flex flex-col items-center pb-[8px]">
+        <strong className="text-2lg font-semibold text-black-400 pc:text-[32px] pc:leading-[46px]">
+          사장님 정보 관리
+        </strong>
+        <label className="relative mt-10 cursor-pointer pc:mt-[50px]">
+          <Image
+            src={previewSrc || "/icon/profile-circle-lg.svg"}
+            alt="프로필사진 변경"
+            width={80}
+            height={80}
+            className="size-20 rounded-full border-4 border-line-100 bg-background-200 object-cover pc:size-[100px]"
+            priority={true}
+          />
+          <Image
+            src="/icon/write-lg.svg"
+            alt="프로필사진 변경버튼"
+            width={24}
+            height={24}
+            className="absolute bottom-2 right-0 size-6 rounded-full border-[3px] border-gray-50 bg-background-300 pc:bottom-0 pc:size-9"
+            priority={true}
+          />
+          <input className="hidden" />
+        </label>
+
+        <form
+          onSubmit={handleSubmit(onSubmit)}
+          className="mt-6 flex flex-col pc:mt-10"
+        >
+          {inputArr.map((input) => (
+            <div key={input.name} className="relative flex flex-col">
+              <label htmlFor={input.name} className={labelStyle}>
+                {input.label}
+                {input.required && <span className="text-red"> *</span>}
+              </label>
+              <FormInput
+                id={input.name}
+                name={input.name as Path<z.infer<typeof changeCEOInfoSchema>>}
+                type={input.type}
+                register={register}
+                error={input.error}
+                placeholder={input.placeholder}
+                className={
+                  input.name === "location" ? `${inputStyle} pl-11` : inputStyle
+                }
+              />
+              <ErrorText error={input.error}>{input.error?.message}</ErrorText>
+              {input.name === "location" ? (
+                <Image
+                  src="/icon/pin-fill-lg.svg"
+                  alt="가게 위치"
+                  width={36}
+                  height={36}
+                  className="absolute bottom-2 left-2"
+                />
+              ) : (
+                ""
+              )}
+            </div>
+          ))}
+
+          <div className="mt-6 flex gap-[11px] pc:mt-[30px] pc:gap-3">
+            <button className="h-[58px] w-[158px] rounded-[8px] border bg-gray-100 text-white pc:h-[72px] pc:w-[314px]">
+              취소
+            </button>
+            <button className="h-[58px] w-[158px] rounded-[8px] border bg-orange-300 text-white pc:h-[72px] pc:w-[314px]">
+              수정하기
+            </button>
+          </div>
+        </form>
+      </div>
+    </ModalContainer>
+  );
 };
 
 export default ChangeCEOInfoModal;
+
+const labelStyle =
+  "text-md font-regular text-black-400 w-fit cursor-pointer mt-[17px] pc:mt-8 pc:text-xl";
+const inputStyle =
+  "mt-[8px] rounded-[8px] bg-grya-50 p-[14px] placeholder:text-md placeholder:font-regular border focus:border-orange-300 pc:mt-4";

--- a/src/components/modal/modalContent/ChangeCEOInfoModal.tsx
+++ b/src/components/modal/modalContent/ChangeCEOInfoModal.tsx
@@ -128,7 +128,7 @@ const ChangeCEOInfoModal = () => {
                 }
               />
               <ErrorText error={input.error}>{input.error?.message}</ErrorText>
-              {input.name === "location" ? (
+              {input.name === "location" && (
                 <Image
                   src="/icon/pin-fill-lg.svg"
                   alt="가게 위치"
@@ -136,8 +136,6 @@ const ChangeCEOInfoModal = () => {
                   height={36}
                   className="absolute bottom-2 left-2"
                 />
-              ) : (
-                ""
               )}
             </div>
           ))}
@@ -161,4 +159,4 @@ export default ChangeCEOInfoModal;
 const labelStyle =
   "text-md font-regular text-black-400 w-fit cursor-pointer mt-[17px] pc:mt-8 pc:text-xl";
 const inputStyle =
-  "mt-[8px] rounded-[8px] bg-grya-50 p-[14px] placeholder:text-md placeholder:font-regular border focus:border-orange-300 pc:mt-4";
+  "mt-[8px] rounded-[8px] bg-gray-50 p-[14px] placeholder:text-md placeholder:font-regular border focus:border-orange-300 pc:mt-4";

--- a/src/components/modal/modalContent/ChangeMyInfoModal.tsx
+++ b/src/components/modal/modalContent/ChangeMyInfoModal.tsx
@@ -28,7 +28,7 @@ const ChangeMyInfoModal = () => {
 
   return (
     <ModalContainer>
-      <div className="flex flex-col items-center pb-[8px] pc:mx-[-40px]">
+      <div className="flex flex-col items-center pb-[8px]">
         <strong className="text-2lg font-semibold text-black-400 pc:text-[32px] pc:leading-[46px]">
           내 정보 수정
         </strong>

--- a/src/components/modal/modalContent/ClosedAlbaformModal.tsx
+++ b/src/components/modal/modalContent/ClosedAlbaformModal.tsx
@@ -4,7 +4,7 @@ import ModalContainer from "../modalContainer/ModalContainer";
 const CloseAlbaformModal = () => {
   return (
     <ModalContainer>
-      <div className="flex flex-col items-center">
+      <div className="flex flex-col items-center pc:mx-10">
         <div className="modal-image-container">
           <Image
             src="/image/search-document-orange.svg"

--- a/src/components/modal/modalContent/DeleteAlbaformModal.tsx
+++ b/src/components/modal/modalContent/DeleteAlbaformModal.tsx
@@ -4,7 +4,7 @@ import ModalContainer from "../modalContainer/ModalContainer";
 const DeleteAlbaformModal = () => {
   return (
     <ModalContainer>
-      <div className="flex flex-col items-center">
+      <div className="flex flex-col items-center pc:mx-10">
         <div className="modal-image-container">
           <Image
             src="/image/email-orange.svg"

--- a/src/components/modal/modalContent/GetMyApplicationModal.tsx
+++ b/src/components/modal/modalContent/GetMyApplicationModal.tsx
@@ -32,7 +32,7 @@ const GetMyApplicationModal = () => {
 
   return (
     <ModalContainer>
-      <div className="flex flex-col pb-[8px] pc:mx-[-40px]">
+      <div className="flex flex-col pb-[8px]">
         <strong className="text-2lg font-semibold text-black-400 pc:text-[32px] pc:leading-[46px]">
           내 지원 내역
         </strong>

--- a/src/components/modal/modalContent/PatchAlbaformModal.tsx
+++ b/src/components/modal/modalContent/PatchAlbaformModal.tsx
@@ -4,7 +4,7 @@ import ModalContainer from "../modalContainer/ModalContainer";
 const PatchAlbaformModal = () => {
   return (
     <ModalContainer>
-      <div className="flex flex-col items-center">
+      <div className="flex flex-col items-center pc:mx-10">
         <div className="modal-image-container">
           <Image
             src="/image/document-edit-orange.svg"

--- a/src/components/modal/modalContent/SelectProgressModal.tsx
+++ b/src/components/modal/modalContent/SelectProgressModal.tsx
@@ -19,7 +19,7 @@ const SelectProgressModal = () => {
 
   return (
     <ModalContainer>
-      <div className="flex flex-col items-center pb-[8px] pt-[4px] pc:mx-[-40px] pc:pb-[8px] pc:pt-[8px]">
+      <div className="flex flex-col items-center pb-[8px] pt-[4px] pc:pb-[8px] pc:pt-[8px]">
         <strong className="modal-title mt-0">진행상태 선택</strong>
         <p className="modal-sub-title">현재 진행상태를 알려주세요.</p>
 

--- a/src/components/modal/modalManager/ModalManager.tsx
+++ b/src/components/modal/modalManager/ModalManager.tsx
@@ -8,6 +8,7 @@ import PatchAlbaformModal from "../modalContent/PatchAlbaformModal";
 import GetMyApplicationModal from "../modalContent/GetMyApplicationModal";
 import SelectProgressModal from "../modalContent/SelectProgressModal";
 import ChangeMyInfoModal from "../modalContent/ChangeMyInfoModal";
+import ChangeCEOInfoModal from "../modalContent/ChangeCEOInfoModal";
 
 const ModalManager = () => {
   const modalType = useAtomValue(modalAtom);
@@ -27,6 +28,8 @@ const ModalManager = () => {
       return <SelectProgressModal />;
     case "ChangeMyInfoModal":
       return <ChangeMyInfoModal />;
+    case "ChangeCEOInfoModal":
+      return <ChangeCEOInfoModal />;
     default:
       return null;
   }

--- a/src/schema/modal/changeCEOInfoSchema.ts
+++ b/src/schema/modal/changeCEOInfoSchema.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+export const changeCEOInfoSchema = z.object({
+  nickname: z.string().min(1, { message: "닉네임을 입력해주세요." }),
+  storeName: z
+    .string()
+    .min(1, { message: "가게 이름(상호명)을 필수로 입력해주세요." })
+    .optional(),
+  storePhoneNumber: z
+    .string()
+    .regex(/^[0-9]*$/, { message: "올바르지 않은 번호입니다." })
+    .optional(),
+  phoneNumber: z
+    .string()
+    .regex(/^(010|011|016|017|018|019)\d{7,8}$/, {
+      message: "올바르지 않은 번호입니다.",
+    })
+    .optional(),
+  location: z
+    .string()
+    .min(1, { message: "가게 위치를 입력해주세요." })
+    .optional(),
+});

--- a/src/schema/modal/changeCEOInfoSchema.ts
+++ b/src/schema/modal/changeCEOInfoSchema.ts
@@ -8,7 +8,7 @@ export const changeCEOInfoSchema = z.object({
     .optional(),
   storePhoneNumber: z
     .string()
-    .regex(/^[0-9]*$/, { message: "올바르지 않은 번호입니다." })
+    .regex(/^[0-9]+$/, { message: "올바르지 않은 번호입니다." })
     .optional(),
   phoneNumber: z
     .string()

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -60,6 +60,16 @@ body {
     @apply max-w-[640px] rounded-lg border-[0.5px] border-gray-200 p-[14px] placeholder:text-gray-400 focus:border-orange-300;
   }
 
+  /* 스크롤바 숨기기 - 전상민 */
+  .scrollbar-hidden {
+    scrollbar-width: none; /* Firefox */
+    -ms-overflow-style: none; /* Internet Explorer 10+ */
+  }
+
+  .scrollbar-hidden::-webkit-scrollbar {
+    display: none; /* Chrome, Safari, Edge */
+  }
+
   /* PC 크기에서 적용될 스타일 */
   @media (min-width: 1200px) {
     .modal-image-container {

--- a/src/types/modal.ts
+++ b/src/types/modal.ts
@@ -5,4 +5,5 @@ export enum ModalType {
   SelectProgressModal = "SelectProgressModal", // 진행상태 선택 모달
   ChangeMyInfoModal = "ChangeMyInfoModal", // 내 정보 수정 모달
   GetMyApplicationModal = "GetMyApplicationModal", // 내 지원 내역 모달
+  ChangeCEOInfoModal = "ChangeCEOInfoModal", // 사장님 정보 관리 모달
 }


### PR DESCRIPTION
## 🧩 이슈 번호 #38 

## 🔎 작업 내용
1. "사장님 정보 관리" 모달 UI 구현
2. 폼 벨류데이션
3. 모달이 길어져서 스크롤로 봐야함 (글로벌에 스크롤 감추는 css 추가함)

## 이미지 첨부

![screencapture-localhost-3000-modaltest-2024-11-27-23_36_43](https://github.com/user-attachments/assets/2e871b4f-a4a1-4341-b5d4-192f843f03dd)


## 🔧 앞으로의 과제

1. 제출 기능 구현
2. 공통 버튼 사용 (모든 모달 한번에 적용하겠습니다)
3. 가게 위치 카카오맵과 연동 필요

## 👩‍💻 공유 포인트 및 논의 사항

모달의 실제 크기가 피그마에서 보여지는 크기보다 큽니다.
