### PR TITLE
Feat: 정보 수정 드롭다운 추가

### DIFF
--- a/src/atoms/dropdownAtomStore.ts
+++ b/src/atoms/dropdownAtomStore.ts
@@ -6,9 +6,6 @@ export const dropdownTriggerAtom = atomFamily((id: string) => atom(false));
 // 전체 - 모집 중 - 모집 마감 드롭다운 (isRecruiting)
 export const applicationStatusAtom = atom<boolean | undefined>(undefined);
 
-// 수정 및 삭제 드롭다운
-export const editDeleteDropdownAtom = atom(false);
-
 // 전체 - 공개 - 비공개 드롭다운 (isPublic)
 export const publicStatusAtom = atom<boolean | undefined>(undefined);
 

--- a/src/components/dropdown/MyInfoEditDropdown.tsx
+++ b/src/components/dropdown/MyInfoEditDropdown.tsx
@@ -6,41 +6,38 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/dropdown/DropdownMenu";
+import Image from "next/image";
 
-// 트리거 요소를 넣으시고, 수정 및 삭제 함수도 전달해서 사용해주세요.
-const EditDeleteDropdown = ({
-  children,
-  onEdit,
-  onDelete,
+const MyInfoEditDropdown = ({
+  onMyInfoEdit,
+  onPasswordEdit,
 }: {
-  children: React.ReactNode;
-  onEdit: () => void;
-  onDelete: () => void;
+  onMyInfoEdit: () => void;
+  onPasswordEdit: () => void;
 }) => {
   const itemArr = [
-    {
-      text: "수정하기",
-      onClick: onEdit,
-    },
-    {
-      text: "삭제하기",
-      onClick: onDelete,
-    },
+    { text: "내 정보 수정", onClick: onMyInfoEdit },
+    { text: "비밀번호 변경", onClick: onPasswordEdit },
   ];
 
   return (
-    <DropdownMenu className="bg-transparent">
+    <DropdownMenu className="bg-transparent pc:hidden">
       <DropdownMenuTrigger
         asChild
-        id="editDelete"
+        id="myInfoEdit"
         checkedValue={undefined}
         className="rounded-lg"
       >
-        {children}
+        <Image
+          src="/icon/kebab-lg.svg"
+          alt="정보 수정 드롭다운"
+          width={24}
+          height={24}
+        />
       </DropdownMenuTrigger>
       <DropdownMenuContent
-        id="editDelete"
-        className="translate-x-[-50px] items-center bg-white p-1 pc:w-[132px] pc:translate-x-[-100px]"
+        id="myInfoEdit"
+        className="w-fit translate-x-[-70px] items-center bg-white p-1"
       >
         {itemArr.map((item) => (
           <DropdownMenuItem
@@ -56,4 +53,4 @@ const EditDeleteDropdown = ({
   );
 };
 
-export default EditDeleteDropdown;
+export default MyInfoEditDropdown;


### PR DESCRIPTION
## 🧩 이슈 번호 #115 

## 🔎 작업 내용
<!-- - 기능에서 어떤 부분이 구현되었는지 설명해주세요. -->
- 내 정보 수정, 비밀번호 변경 드롭다운을 구현했습니다.
- 다음 코드와 같이 사용이 가능합니다.
```
const handleMyInfoEdit = () => {
  // 수정 로직
}

const handlePasswordEdit = () => {
  // 비밀번호 변경 로직 또는 모달 연결
}

return <MyInfoEditDropdown onMyInfoEdit={handleMyInfoEdit} onPasswordEdit={handlePasswordEdit} />
```

## 이미지 첨부
<!-- preview 이미지 혹 동영상을 첨부해주세요. -->
![정보수정 드롭다운](https://github.com/user-attachments/assets/1e00bf1d-61a2-4934-9e82-b3c60bf8f579)

## 🔧 앞으로의 과제

<!-- - 이번 이슈에서 앞으로 남은 할 일을 적어주세요. -->
- 알바토크 게시글 정렬 드롭다운
- 알바폼 생성 드롭다운

## 👩‍💻 공유 포인트 및 논의 사항

<!-- 공유하거나 논의할 사항을 작성해주세요. -->
- 불필요한 atom 상태를 삭제했습니다.
- atom 삭제로 수정 및 삭제 드롭다운에도 반영하여 수정했습니다.
- 수정 및 삭제 드롭다운의 반응형 위치가 잘못되어 수정했습니다.
