### PR TITLE
Refactor:모달 내 공통 버튼 사용

### DIFF
--- a/src/components/button/SolidButton.tsx
+++ b/src/components/button/SolidButton.tsx
@@ -51,7 +51,7 @@ const SolidButton = ({
   };
 
   // 공통
-  const commonClass = `flex items-center gap-x-2 font-semibold rounded-lg justify-center transition-transform duration-200 ease-out hover:opacity-90}`;
+  const commonClass = `flex items-center gap-x-2 font-semibold rounded-lg justify-center transition-transform duration-200 ease-out hover:opacity-90`;
 
   // 최종 스타일
   const finalClassName = `${commonClass} ${sizeStyle[size]} ${buttonStyles[style]}`;

--- a/src/components/modal/modalContent/ChangeCEOInfoModal.tsx
+++ b/src/components/modal/modalContent/ChangeCEOInfoModal.tsx
@@ -9,12 +9,18 @@ import { useForm, Path } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { changeCEOInfoSchema } from "@/schema/modal/changeCEOInfoSchema";
+import SolidButton from "@/components/button/SolidButton";
+import { useModal } from "@/hooks/useModal";
+import useViewPort from "@/hooks/useViewport";
 
 const ChangeCEOInfoModal = () => {
+  const { closeModal } = useModal();
+  const viewPort = useViewPort();
   const [previewSrc, setPreviewSrc] = useState("");
   const {
     register,
     handleSubmit,
+    watch,
     formState: { errors, isValid, isSubmitting },
   } = useForm<z.infer<typeof changeCEOInfoSchema>>({
     resolver: zodResolver(changeCEOInfoSchema),
@@ -27,6 +33,12 @@ const ChangeCEOInfoModal = () => {
       location: "",
     },
   });
+
+  const isRequiredValid =
+    !watch("nickname") ||
+    !watch("storeName") ||
+    !watch("storePhoneNumber") ||
+    !watch("location");
 
   const inputArr = [
     {
@@ -141,12 +153,31 @@ const ChangeCEOInfoModal = () => {
           ))}
 
           <div className="mt-6 flex gap-[11px] pc:mt-[30px] pc:gap-3">
-            <button className="h-[58px] w-[158px] rounded-[8px] border bg-gray-100 text-white pc:h-[72px] pc:w-[314px]">
-              취소
-            </button>
-            <button className="h-[58px] w-[158px] rounded-[8px] border bg-orange-300 text-white pc:h-[72px] pc:w-[314px]">
-              수정하기
-            </button>
+            <div className={buttmonContainerStyle}>
+              <SolidButton
+                size={viewPort === "pc" ? "large" : "small"}
+                style="gray100"
+                type="button"
+                onClick={() => {
+                  closeModal();
+                }}
+              >
+                취소
+              </SolidButton>
+            </div>
+            <div className={buttmonContainerStyle}>
+              <SolidButton
+                disabled={isRequiredValid || isSubmitting}
+                size={viewPort === "pc" ? "large" : "small"}
+                style="orange300"
+                type="submit"
+                onClick={() => {
+                  closeModal();
+                }}
+              >
+                수정하기
+              </SolidButton>
+            </div>
           </div>
         </form>
       </div>
@@ -160,3 +191,4 @@ const labelStyle =
   "text-md font-regular text-black-400 w-fit cursor-pointer mt-[17px] pc:mt-8 pc:text-xl";
 const inputStyle =
   "mt-[8px] rounded-[8px] bg-gray-50 p-[14px] placeholder:text-md placeholder:font-regular border focus:border-orange-300 pc:mt-4";
+const buttmonContainerStyle = "h-[58px] w-[158px] pc:h-[72px] pc:w-[314px]";

--- a/src/components/modal/modalContent/ChangeMyInfoModal.tsx
+++ b/src/components/modal/modalContent/ChangeMyInfoModal.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Image from "next/image";
 import ModalContainer from "../modalContainer/ModalContainer";
 import FormInput from "@/components/input/FormInput";
@@ -7,8 +9,13 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { changeMyInfoSchema } from "@/schema/modal/changeMyInfoSchema";
 import { z } from "zod";
+import SolidButton from "@/components/button/SolidButton";
+import useViewPort from "@/hooks/useViewport";
+import { useModal } from "@/hooks/useModal";
 
 const ChangeMyInfoModal = () => {
+  const { closeModal } = useModal();
+  const viewPort = useViewPort();
   const [previewSrc, setPreviewSrc] = useState("");
   const {
     register,
@@ -110,12 +117,31 @@ const ChangeMyInfoModal = () => {
           </div>
 
           <div className="mt-6 flex gap-[11px] pc:mt-[30px] pc:gap-3">
-            <button className="h-[58px] w-[158px] rounded-[8px] border bg-gray-100 text-white pc:h-[72px] pc:w-[314px]">
-              취소
-            </button>
-            <button className="h-[58px] w-[158px] rounded-[8px] border bg-orange-300 text-white pc:h-[72px] pc:w-[314px]">
-              수정하기
-            </button>
+            <div className={buttmonContainerStyle}>
+              <SolidButton
+                size={viewPort === "pc" ? "large" : "small"}
+                style="gray100"
+                type="button"
+                onClick={() => {
+                  closeModal();
+                }}
+              >
+                취소
+              </SolidButton>
+            </div>
+            <div className={buttmonContainerStyle}>
+              <SolidButton
+                disabled={!isValid || isSubmitting}
+                size={viewPort === "pc" ? "large" : "small"}
+                style="orange300"
+                type="submit"
+                onClick={() => {
+                  closeModal();
+                }}
+              >
+                수정하기
+              </SolidButton>
+            </div>
           </div>
         </form>
       </div>
@@ -129,3 +155,4 @@ const labelStyle =
   "text-md font-regular text-black-400 w-fit cursor-pointer pc:text-lg";
 const inputStyle =
   "mt-[8px] rounded-[8px] bg-gray-50 p-[14px] placeholder:text-md placeholder:font-regular border focus:boder-orange-300";
+const buttmonContainerStyle = "h-[58px] w-[158px] pc:h-[72px] pc:w-[314px]";

--- a/src/components/modal/modalContent/ChangePasswordModal.tsx
+++ b/src/components/modal/modalContent/ChangePasswordModal.tsx
@@ -9,8 +9,13 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { useForm, Path } from "react-hook-form";
 import { changePasswordSchema } from "@/schema/modal/changePasswordSchema";
+import SolidButton from "@/components/button/SolidButton";
+import { useModal } from "@/hooks/useModal";
+import useViewPort from "@/hooks/useViewport";
 
 const ChangePasswordModal = () => {
+  const { closeModal } = useModal();
+  const viewPort = useViewPort();
   const [visible, setVisible] = useState({
     currentPassword: false,
     newPassword: false,
@@ -71,7 +76,7 @@ const ChangePasswordModal = () => {
 
   return (
     <ModalContainer>
-      <div className="flex flex-col items-center pb-[8px] pc:mx-[-40px]">
+      <div className="flex flex-col items-center pb-[8px]">
         <strong className="text-2lg font-semibold text-black-400 pc:text-[32px] pc:leading-[46px]">
           비밀번호 변경
         </strong>
@@ -114,12 +119,31 @@ const ChangePasswordModal = () => {
           ))}
 
           <div className="mt-6 flex gap-[11px] pc:mt-[30px] pc:gap-3">
-            <button className="h-[58px] w-[158px] rounded-[8px] border bg-gray-100 text-white pc:h-[72px] pc:w-[314px]">
-              취소
-            </button>
-            <button className="h-[58px] w-[158px] rounded-[8px] border bg-orange-300 text-white pc:h-[72px] pc:w-[314px]">
-              수정하기
-            </button>
+            <div className={buttmonContainerStyle}>
+              <SolidButton
+                size={viewPort === "pc" ? "large" : "small"}
+                style="gray100"
+                type="button"
+                onClick={() => {
+                  closeModal();
+                }}
+              >
+                취소
+              </SolidButton>
+            </div>
+            <div className={buttmonContainerStyle}>
+              <SolidButton
+                disabled={!isValid || isSubmitting}
+                size={viewPort === "pc" ? "large" : "small"}
+                style="orange300"
+                type="submit"
+                onClick={() => {
+                  closeModal();
+                }}
+              >
+                수정하기
+              </SolidButton>
+            </div>
           </div>
         </form>
       </div>
@@ -133,3 +157,4 @@ const labelStyle =
   "text-md font-regular text-black-400 w-fit cursor-pointer pc:text-xl";
 const inputStyle =
   "mt-2 rounded-[8px] bg-gray-50 p-[14px] pr-10 placeholder:text-lg placeholder:font-regular border focus:border-orange-300 pc:mt-4";
+const buttmonContainerStyle = "h-[58px] w-[158px] pc:h-[72px] pc:w-[314px]";

--- a/src/components/modal/modalContent/ClosedAlbaformModal.tsx
+++ b/src/components/modal/modalContent/ClosedAlbaformModal.tsx
@@ -1,7 +1,17 @@
+"use client";
+
 import Image from "next/image";
 import ModalContainer from "../modalContainer/ModalContainer";
+import SolidButton from "@/components/button/SolidButton";
+import useViewPort from "@/hooks/useViewport";
+import { useRouter } from "next/navigation";
+import { useModal } from "@/hooks/useModal";
 
 const CloseAlbaformModal = () => {
+  const router = useRouter();
+  const { closeModal } = useModal();
+  const viewPort = useViewPort();
+
   return (
     <ModalContainer>
       <div className="flex flex-col items-center pc:mx-10">
@@ -13,11 +23,21 @@ const CloseAlbaformModal = () => {
             className="object-cover"
           />
         </div>
-        <strong className="modal-title">모집 마감</strong>
+        <h2 className="modal-title">모집 마감</h2>
         <p className="modal-sub-title">모집이 종료된 알바폼 입니다.</p>
-        <button className="mt-[24px] h-[56px] w-[327px] border bg-gray-400 pc:h-[72px] pc:w-[360px]">
-          홈으로 가기
-        </button>
+        <div className="mt-6 h-[56px] w-[327px] pc:h-[72px] pc:w-[360px]">
+          <SolidButton
+            size={viewPort === "pc" ? "large" : "small"}
+            style="orange300"
+            type="button"
+            onClick={() => {
+              closeModal();
+              router.push("/");
+            }}
+          >
+            홈으로 가기
+          </SolidButton>
+        </div>
       </div>
     </ModalContainer>
   );

--- a/src/components/modal/modalContent/DeleteAlbaformModal.tsx
+++ b/src/components/modal/modalContent/DeleteAlbaformModal.tsx
@@ -1,7 +1,20 @@
+"use client";
+
 import Image from "next/image";
 import ModalContainer from "../modalContainer/ModalContainer";
+import SolidButton from "@/components/button/SolidButton";
+import useViewPort from "@/hooks/useViewport";
+import { useModal } from "@/hooks/useModal";
 
 const DeleteAlbaformModal = () => {
+  const { closeModal } = useModal();
+  const viewPort = useViewPort();
+
+  const handleDeleteAlbaform = () => {
+    // 알바폼 삭제 api 요청
+    // 요청 후 토스트 생성
+  };
+
   return (
     <ModalContainer>
       <div className="flex flex-col items-center pc:mx-10">
@@ -13,12 +26,25 @@ const DeleteAlbaformModal = () => {
             className="object-cover"
           />
         </div>
-        <strong className="modal-title">알바폼을 삭제할까요?</strong>
+        <h2 className="modal-title">알바폼을 삭제할까요?</h2>
         <p className="modal-sub-title">삭제 후 정보를 복구할 수 없어요.</p>
-        <button className="mt-[24px] h-[56px] w-[327px] border bg-gray-400 pc:h-[72px] pc:w-[360px]">
-          시작하기
-        </button>
-        <p className="mt-[16px] cursor-pointer text-lg font-regular text-orange-300 pc:mt-[20px] pc:text-xl">
+        <div className="mt-6 h-[56px] w-[327px] pc:h-[72px] pc:w-[360px]">
+          <SolidButton
+            size={viewPort === "pc" ? "large" : "small"}
+            style="orange300"
+            type="button"
+            onClick={() => {
+              closeModal();
+              handleDeleteAlbaform;
+            }}
+          >
+            시작하기
+          </SolidButton>
+        </div>
+        <p
+          onClick={() => closeModal()}
+          className="mt-[16px] cursor-pointer text-lg font-regular text-orange-300 pc:mt-[20px] pc:text-xl"
+        >
           다음에 할게요
         </p>
       </div>

--- a/src/components/modal/modalContent/GetMyApplicationModal.tsx
+++ b/src/components/modal/modalContent/GetMyApplicationModal.tsx
@@ -9,8 +9,13 @@ import FormInput from "@/components/input/FormInput";
 import ErrorText from "@/components/errorText/ErrorText";
 import Image from "next/image";
 import { useState } from "react";
+import SolidButton from "@/components/button/SolidButton";
+import { useModal } from "@/hooks/useModal";
+import useViewPort from "@/hooks/useViewport";
 
 const GetMyApplicationModal = () => {
+  const { closeModal } = useModal();
+  const viewPort = useViewPort();
   const [visible, setVisible] = useState(false);
   const {
     register,
@@ -33,9 +38,9 @@ const GetMyApplicationModal = () => {
   return (
     <ModalContainer>
       <div className="flex flex-col pb-[8px]">
-        <strong className="text-2lg font-semibold text-black-400 pc:text-[32px] pc:leading-[46px]">
+        <h2 className="text-2lg font-semibold text-black-400 pc:text-[32px] pc:leading-[46px]">
           내 지원 내역
-        </strong>
+        </h2>
         <div className="mt-6 text-md font-medium text-gray-400 pc:mt-8 pc:text-lg">
           <p>
             지원일시{" "}
@@ -113,11 +118,21 @@ const GetMyApplicationModal = () => {
               {errors.password?.message}
             </ErrorText>
           </div>
-        </form>
 
-        <button className="mt-[24px] w-[327px] rounded-[8px] bg-orange-300 p-[16px] text-white pc:mt-[46px]">
-          지원 내역 상세 보기
-        </button>
+          <div className="mt-6 w-[327px] pc:mt-[46px] pc:w-[360px]">
+            <SolidButton
+              disabled={!isValid || isSubmitting}
+              size={viewPort === "pc" ? "large" : "small"}
+              style="orange300"
+              type="submit"
+              onClick={() => {
+                closeModal();
+              }}
+            >
+              지원 내역 상세 보기
+            </SolidButton>
+          </div>
+        </form>
       </div>
     </ModalContainer>
   );
@@ -128,4 +143,4 @@ export default GetMyApplicationModal;
 const labelStyle =
   "text-md font-regular text-black-400 w-fit cursor-pointer pc:text-lg";
 const inputStyle =
-  "mt-[8px] rounded-[8px] bg-background-200 p-[14px] placeholder:text-md placeholder:font-regular border focus:outline-orange-300";
+  "mt-[8px] rounded-[8px] bg-background-200 p-[14px] placeholder:text-md placeholder:font-regular border focus:border-orange-300";

--- a/src/components/modal/modalContent/PatchAlbaformModal.tsx
+++ b/src/components/modal/modalContent/PatchAlbaformModal.tsx
@@ -1,7 +1,17 @@
+"use client";
+
 import Image from "next/image";
 import ModalContainer from "../modalContainer/ModalContainer";
+import SolidButton from "@/components/button/SolidButton";
+import useViewPort from "@/hooks/useViewport";
+import { useRouter } from "next/navigation";
+import { useModal } from "@/hooks/useModal";
 
 const PatchAlbaformModal = () => {
+  const router = useRouter();
+  const { closeModal } = useModal();
+  const viewPort = useViewPort();
+
   return (
     <ModalContainer>
       <div className="flex flex-col items-center pc:mx-10">
@@ -13,11 +23,21 @@ const PatchAlbaformModal = () => {
             className="object-cover"
           />
         </div>
-        <strong className="modal-title">작성 중인 알바폼이 있어요!</strong>
+        <h2 className="modal-title">작성 중인 알바폼이 있어요!</h2>
         <p className="modal-sub-title">이어서 작성하시겠어요?</p>
-        <button className="mt-[24px] h-[56px] w-[327px] border bg-gray-400 pc:h-[72px] pc:w-[360px]">
-          이어쓰기
-        </button>
+        <div className="mt-6 h-[56px] w-[327px] pc:h-[72px] pc:w-[360px]">
+          <SolidButton
+            size={viewPort === "pc" ? "large" : "small"}
+            style="orange300"
+            type="button"
+            onClick={() => {
+              closeModal();
+              router.push("/addform");
+            }}
+          >
+            이어쓰기
+          </SolidButton>
+        </div>
       </div>
     </ModalContainer>
   );

--- a/src/components/modal/modalContent/SelectProgressModal.tsx
+++ b/src/components/modal/modalContent/SelectProgressModal.tsx
@@ -1,7 +1,10 @@
 "use client";
 
-import { useState } from "react";
 import ModalContainer from "../modalContainer/ModalContainer";
+import SolidButton from "@/components/button/SolidButton";
+import useViewPort from "@/hooks/useViewport";
+import { useState } from "react";
+import { useModal } from "@/hooks/useModal";
 
 const progressList = [
   { name: "거절" },
@@ -11,16 +14,22 @@ const progressList = [
 ];
 
 const SelectProgressModal = () => {
-  const [selected, setSelected] = useState("");
+  const { closeModal } = useModal();
+  const viewPort = useViewPort();
+  const [selected, setSelected] = useState("면접 대기");
 
   const handleChange = (value: string) => {
     setSelected(value);
   };
 
+  const handleSubmit = () => {
+    // 지원 상태 수정 api 요청
+  };
+
   return (
     <ModalContainer>
       <div className="flex flex-col items-center pb-[8px] pt-[4px] pc:pb-[8px] pc:pt-[8px]">
-        <strong className="modal-title mt-0">진행상태 선택</strong>
+        <h2 className="modal-title mt-0">진행상태 선택</h2>
         <p className="modal-sub-title">현재 진행상태를 알려주세요.</p>
 
         <ul className="mt-[24px] flex w-full flex-col gap-[10px] pc:mt-12">
@@ -44,12 +53,31 @@ const SelectProgressModal = () => {
         </ul>
 
         <div className="mt-[30px] flex gap-[11px] pc:gap-[8px]">
-          <button className="h-[58px] w-[158px] rounded-[8px] border bg-gray-100 text-white pc:h-[72px] pc:w-[176px]">
-            취소
-          </button>
-          <button className="h-[58px] w-[158px] rounded-[8px] border bg-orange-300 text-gray-50 pc:h-[72px] pc:w-[176px]">
-            선택하기
-          </button>
+          <div className={buttmonContainerStyle}>
+            <SolidButton
+              size={viewPort === "pc" ? "large" : "small"}
+              style="gray100"
+              type="button"
+              onClick={() => {
+                closeModal();
+              }}
+            >
+              취소
+            </SolidButton>
+          </div>
+          <div className={buttmonContainerStyle}>
+            <SolidButton
+              size={viewPort === "pc" ? "large" : "small"}
+              style="orange300"
+              type="button"
+              onClick={() => {
+                closeModal();
+                handleSubmit;
+              }}
+            >
+              선택하기
+            </SolidButton>
+          </div>
         </div>
       </div>
     </ModalContainer>
@@ -57,3 +85,5 @@ const SelectProgressModal = () => {
 };
 
 export default SelectProgressModal;
+
+const buttmonContainerStyle = "h-[58px] w-[158px] pc:h-[72px] pc:w-[176px]";

--- a/src/schema/modal/changeCEOInfoSchema.ts
+++ b/src/schema/modal/changeCEOInfoSchema.ts
@@ -4,20 +4,15 @@ export const changeCEOInfoSchema = z.object({
   nickname: z.string().min(1, { message: "닉네임을 입력해주세요." }),
   storeName: z
     .string()
-    .min(1, { message: "가게 이름(상호명)을 필수로 입력해주세요." })
-    .optional(),
+    .min(1, { message: "가게 이름(상호명)을 필수로 입력해주세요." }),
   storePhoneNumber: z
     .string()
-    .regex(/^[0-9]+$/, { message: "올바르지 않은 번호입니다." })
-    .optional(),
+    .regex(/^[0-9]+$/, { message: "올바르지 않은 번호입니다." }),
   phoneNumber: z
     .string()
-    .regex(/^(010|011|016|017|018|019)\d{7,8}$/, {
+    .regex(/^(|010|011|016|017|018|019)\d{7,8}$/, {
       message: "올바르지 않은 번호입니다.",
     })
-    .optional(),
-  location: z
-    .string()
-    .min(1, { message: "가게 위치를 입력해주세요." })
-    .optional(),
+    .nullish(),
+  location: z.string().min(1, { message: "가게 위치를 입력해주세요." }),
 });

--- a/src/schema/modal/changePasswordSchema.ts
+++ b/src/schema/modal/changePasswordSchema.ts
@@ -2,7 +2,6 @@ import { z } from "zod";
 
 const passwordValidation = z
   .string()
-  .min(1, { message: "비밀번호를 입력해주세요." })
   .max(12, { message: "비밀번호는 12자 이내여야합니다." })
   .regex(
     /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!\"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~]).{7,}$/,

--- a/src/schema/modal/getMyApplicationSchema.ts
+++ b/src/schema/modal/getMyApplicationSchema.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 const passwordRegex =
-  /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*?&#/+-])[A-Za-z\d@$!%*?&#/+-]{7,}$/;
+  /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!\"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~]).{7,}$/;
 
 export const getMyApplicationSchema = z.object({
   name: z.string().min(1, { message: "이름을 입력해주세요." }).optional(),
@@ -10,8 +10,9 @@ export const getMyApplicationSchema = z.object({
   }),
   password: z
     .string()
+    .max(12, { message: "비밀번호는 12자 이내여야합니다." })
     .regex(passwordRegex, {
-      message: "특수문자 포함 7자 이상 입력해주세요.",
+      message: "특수문자, 문자, 숫자 포함 7자 이상 입력해주세요.",
     })
     .trim(),
 });


### PR DESCRIPTION
## 🧩 이슈 번호 #7 

## 🔎 작업 내용
1. 8개 모달 컨탠츠에 공통 버튼 컴포넌트를 사용했습니다.
2. 모달 제목 시멘틱 태그 변경했습니다 : strong -> h2
3. 비밀번호 zod 스키마 변경했습니다 (12자 제한, 에러 문구 수정)

모달 사용법

1. useModal 임포트
2. openModal 구조분해하여 원하는 타입 인자로 받아 사용
```
 const { openModal } = useMoadl();

 <button onClick=(() => openModal('원하는 타입'))> 
```

## 🔧 앞으로의 과제
제출 폼 기능 구현 필요
