### PR TITLE
Feat: 알바폼 생성 시 단계별 드롭다운 추가

### DIFF
--- a/public/icon/albaform-dropdown-off.svg
+++ b/public/icon/albaform-dropdown-off.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6 15L12 9L18 15" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/icon/albaform-dropdown-on.svg
+++ b/public/icon/albaform-dropdown-on.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6 9L12 15L18 9" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/atoms/dropdownAtomStore.ts
+++ b/src/atoms/dropdownAtomStore.ts
@@ -25,3 +25,14 @@ export const orderByAtom = atom<OrderBy>({
   title: "최신 순",
   value: "mostRecent",
 });
+
+// 알바폼 생성 드롭다운
+interface AlbaformCreateStep {
+  title: string;
+  value: string;
+}
+
+export const albaformCreateStepAtom = atom<AlbaformCreateStep>({
+  title: "모집 내용",
+  value: "stepOne",
+});

--- a/src/components/dropdown/AlbaformCreateDropdown.tsx
+++ b/src/components/dropdown/AlbaformCreateDropdown.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import {
+  albaformCreateStepAtom,
+  dropdownTriggerAtom,
+} from "@/atoms/dropdownAtomStore";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/dropdown/DropdownMenu";
+import { useAtom, useAtomValue } from "jotai";
+import Image from "next/image";
+import { useState } from "react";
+
+// 알바폼 생성 컴포넌트에서 currentStep 값을 받아서 단계별 form을 표출하는데 사용하세요.
+// currentStep.value 형식으로 받으셔야 합니다.
+const AlbaformCreateDropdown = () => {
+  const [stepNum, setStepNum] = useState(1);
+  const [currentStep, setCurrentStep] = useAtom(albaformCreateStepAtom);
+  const isOpen = useAtomValue(dropdownTriggerAtom("albaformCreate"));
+
+  const handleClick = (value: string, stepNum: number, title: string) => {
+    setCurrentStep({ title, value });
+    setStepNum(stepNum);
+  };
+
+  const itemArr = [
+    { title: "모집 내용", value: "stepOne", stepNum: 1 },
+    { title: "모집 조건", value: "stepTwo", stepNum: 2 },
+    { title: "근무 조건", value: "stepThree", stepNum: 3 },
+  ];
+
+  return (
+    <DropdownMenu className="pc:hidden">
+      <DropdownMenuTrigger
+        asChild
+        id="albaformCreate"
+        checkedValue={currentStep.value}
+      >
+        <div className="group flex w-[327px] items-center justify-between rounded-2xl bg-orange-300 px-6 py-3">
+          <div className="flex items-center space-x-3">
+            <span className="flex size-5 items-center justify-center rounded-full bg-white text-md font-bold text-orange-300">
+              {stepNum}
+            </span>
+            <h2 className="text-md font-bold text-white">
+              {currentStep.title}
+            </h2>
+            <CreatingTag />
+          </div>
+          <Image
+            src={
+              isOpen
+                ? "/icon/albaform-dropdown-off.svg"
+                : "/icon/albaform-dropdown-on.svg"
+            }
+            alt="알바폼 생성 드롭다운"
+            width={24}
+            height={24}
+          />
+        </div>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        id="albaformCreate"
+        className="w-[327px] rounded-2xl bg-orange-300"
+      >
+        {itemArr.map((item) => (
+          <DropdownMenuItem
+            key={item.value}
+            onClick={() => handleClick(item.value, item.stepNum, item.title)}
+            className="border-line-200"
+          >
+            {item.value !== currentStep.value && (
+              <div className="group flex items-center space-x-3 bg-white px-6 py-3 transition-colors hover:bg-orange-300">
+                <span className="flex size-5 items-center justify-center rounded-full bg-background-300 text-md font-bold text-gray-200 hover:bg-orange-300 group-hover:bg-orange-50 group-hover:text-orange-300">
+                  {item.stepNum}
+                </span>
+                <h2 className="text-md font-bold text-black-100 group-hover:text-white">
+                  {item.title}
+                </h2>
+              </div>
+            )}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
+
+export default AlbaformCreateDropdown;
+
+const CreatingTag = () => {
+  return (
+    <div className="rounded-full border-[1px] border-white bg-orange-200 px-2 py-1 text-xs text-white">
+      작성중
+    </div>
+  );
+};


### PR DESCRIPTION
## 🧩 이슈 번호 #87 

## 🔎 작업 내용
<!-- - 기능에서 어떤 부분이 구현되었는지 설명해주세요. -->
- 알바폼 생성 시 태블릿, 모바일화면에서 사이드바 대신 동작할 단계별 드롭다운을 구현했습니다.
- 사용은 다음 예시코드처럼 하실 수 있습니다.
- 아래 예시는 클라이언트 컴포넌트에서의 예시이고, 서버컴포넌트에서 아래와 같은 구조를 사용하신다면 atom 대신 url에 각 단계에 해당하는 값(ex. stepOne)을 단계별 클라이언트 컴포넌트에서 searchParams로 전달해주시는 방식으로 이용하실 수 있습니다. (회원가입 참조)
```
const step = useAtomValue(albaformCreateStepAtom);

console.log(step.value);

return (
  <>
      <AlbaformCreateDropdown />
      {step.value === "stepOne" && <StepOneComponent />}
      {step.value === "stepTwo" && <StepTwoComponent />}
      {step.value === "stepThree" && <StepThreeComponent />}
  </>
);
```

## 이미지 첨부
<!-- preview 이미지 혹 동영상을 첨부해주세요. -->
![알바폼 생성 드롭다운](https://github.com/user-attachments/assets/63436a0c-0926-4075-b999-171b7793a6c3)

## 🔧 앞으로의 과제

<!-- - 이번 이슈에서 앞으로 남은 할 일을 적어주세요. -->
- 알바토크 전용 게시글 정렬 드롭다운
- 쿠키관리로직 서버컴포넌트 이동

## 👩‍💻 공유 포인트 및 논의 사항

<!-- 공유하거나 논의할 사항을 작성해주세요. -->

