### PR TITLE
Style: Toast 기본 유형 변경 및 유형별 아이콘 수정

### DIFF
--- a/public/icon/info-lg.svg
+++ b/public/icon/info-lg.svg
@@ -1,0 +1,5 @@
+<svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="18" cy="18" r="11" fill="#DEDEDE"/>
+<rect x="17" y="11" width="2" height="10" fill="#3E415B"/>
+<circle cx="18" cy="24" r="1" fill="#3E415B"/>
+</svg>

--- a/public/icon/info-md.svg
+++ b/public/icon/info-md.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12" cy="12.0781" r="8" fill="#DEDEDE"/>
+<rect x="11" y="7.07812" width="2" height="7" fill="#3E415B"/>
+<circle cx="12" cy="16.0781" r="1" fill="#3E415B"/>
+</svg>

--- a/src/components/toast/ToastItem.tsx
+++ b/src/components/toast/ToastItem.tsx
@@ -4,14 +4,24 @@ import closeIcon from "@/../public/icon/close-md.svg";
 import closeIconLarge from "@/../public/icon/close-lg.svg";
 import userIcon from "@/../public/icon/user-md.svg";
 import userIconLarge from "@/../public/icon/user-lg.svg";
+import checkIcon from "@/../public/icon/check-md.svg";
+import checkIconLarge from "@/../public/icon/check-lg.svg";
+import infoIcon from "@/../public/icon/info-md.svg";
+import infoIconLarge from "@/../public/icon/info-lg.svg";
 
 const backgroundDefaultColor =
   "bg-[linear-gradient(0deg,rgba(42,44,61,0.9),rgba(42,44,61,0.9)),linear-gradient(0deg,rgba(0,0,0,0.2),rgba(0,0,0,0.2))]";
 
 const toastTypeStyles = {
   info: `${backgroundDefaultColor} text-white`,
-  warning: `${backgroundDefaultColor} text-orange-100`,
-  error: `${backgroundDefaultColor} text-red`,
+  success: `${backgroundDefaultColor} text-white`,
+  warning: `${backgroundDefaultColor} text-white`,
+};
+
+const toastIcons = {
+  info: { mobile: userIcon, pc: userIconLarge },
+  success: { mobile: checkIcon, pc: checkIconLarge },
+  warning: { mobile: infoIcon, pc: infoIconLarge },
 };
 
 interface ToastItemProps {
@@ -20,54 +30,58 @@ interface ToastItemProps {
   onRemove: (id: string) => void;
 }
 
-const ToastItem = ({ toast, isOutAnimating, onRemove }: ToastItemProps) => (
-  <div
-    className={`flex w-[347px] items-center justify-between rounded-[14px] px-6 py-3 text-[13px] font-medium opacity-95 pc:h-[84px] pc:w-[1165px] pc:px-10 pc:py-6 pc:text-xl ${toastTypeStyles[toast.type || "info"]} ${
-      isOutAnimating ? "animate-toast-out" : "animate-toast-in"
-    }`}
-  >
-    <div className="flex items-center gap-x-1 pc:gap-x-2">
-      <Image
-        src={userIcon}
-        width={24}
-        height={24}
-        alt="toast icon"
-        className="block pc:hidden"
-      />
-      <Image
-        src={userIconLarge}
-        width={36}
-        height={36}
-        alt="toast icon"
-        className="hidden pc:block"
-      />
-      {typeof toast.message === "string" ? (
-        <span>{toast.message}</span>
-      ) : (
-        toast.message
-      )}
-    </div>
-    <button
-      className="ml-4 text-sm underline"
-      onClick={() => onRemove(toast.id)}
-      aria-label="Close"
+const ToastItem = ({ toast, isOutAnimating, onRemove }: ToastItemProps) => {
+  const icon = toastIcons[toast.type || "info"];
+
+  return (
+    <div
+      className={`flex w-[347px] items-center justify-between rounded-[14px] px-6 py-3 text-[13px] font-medium opacity-95 pc:h-[84px] pc:w-[1165px] pc:px-10 pc:py-6 pc:text-xl ${toastTypeStyles[toast.type || "info"]} ${
+        isOutAnimating ? "animate-toast-out" : "animate-toast-in"
+      } shadow-md shadow-white`}
     >
-      <Image
-        src={closeIcon}
-        width={24}
-        height={24}
-        alt="close toast"
-        className="block pc:hidden"
-      />
-      <Image
-        src={closeIconLarge}
-        width={36}
-        height={36}
-        alt="close toast"
-        className="hidden pc:block"
-      />
-    </button>
-  </div>
-);
+      <div className="flex items-center gap-x-1 pc:gap-x-2">
+        <Image
+          src={icon.mobile}
+          width={24}
+          height={24}
+          alt="toast icon"
+          className="block pc:hidden"
+        />
+        <Image
+          src={icon.pc}
+          width={36}
+          height={36}
+          alt="toast icon"
+          className="hidden pc:block"
+        />
+        {typeof toast.message === "string" ? (
+          <span>{toast.message}</span>
+        ) : (
+          toast.message
+        )}
+      </div>
+      <button
+        className="ml-4 text-sm underline"
+        onClick={() => onRemove(toast.id)}
+        aria-label="Close"
+      >
+        <Image
+          src={closeIcon}
+          width={24}
+          height={24}
+          alt="close toast"
+          className="block pc:hidden"
+        />
+        <Image
+          src={closeIconLarge}
+          width={36}
+          height={36}
+          alt="close toast"
+          className="hidden pc:block"
+        />
+      </button>
+    </div>
+  );
+};
 
 export default ToastItem;

--- a/src/types/toast.ts
+++ b/src/types/toast.ts
@@ -1,5 +1,5 @@
 export interface ToastType {
   id: string;
   message: string | JSX.Element;
-  type?: "info" | "warning" | "error";
+  type?: "info" | "success" | "warning";
 }


### PR DESCRIPTION
## 🧩 이슈 번호 #12 

## 🔎 작업 내용
- 기본 유형 info, success, warning으로 변경했습니다.
- 유형별 아이콘 수정했습니다.

## 이미지 첨부
![toast](https://github.com/user-attachments/assets/575df2dc-4073-4128-a0ff-4fb14a14b9a8)