### PR TITLE
Feat: 알바폼 만들기 페이지 작성취소 버튼 추가

### DIFF
--- a/src/app/addform/components/StepButton.tsx
+++ b/src/app/addform/components/StepButton.tsx
@@ -1,4 +1,3 @@
-import useViewPort from "@/hooks/useViewport";
 import { cls } from "@/utils/dynamicTailwinds";
 import { useEffect } from "react";
 import WritingTag from "./WritingTag";
@@ -6,7 +5,6 @@ import { addFormStepAtom } from "@/atoms/addFormAtom";
 import { useAtom } from "jotai";
 
 const StepButton = () => {
-  const viewport = useViewPort();
   const [currentStep, setCurrentStep] = useAtom(addFormStepAtom);
   const stepArr = [
     { title: "모집 내용", step: 1, value: "stepOne" },
@@ -21,26 +19,24 @@ const StepButton = () => {
   };
 
   const handleClickStep = (value: string) => {
-    setCurrentStep(value);
+    setCurrentStep({
+      title: stepArr.find((item) => item.value === value)?.title,
+      value,
+      stepNum: stepArr.find((item) => item.value === value)?.step,
+    });
     updateURL(value);
   };
 
   useEffect(() => {
-    if (viewport === "pc") {
-      updateURL(currentStep);
-    } else {
-      const params = new URLSearchParams(window.location.search);
-      params.delete("step");
-      window.history.pushState({}, "", `?${params}`);
-    }
-  }, [currentStep, viewport]);
+    updateURL(currentStep.value);
+  }, [currentStep]);
 
   return stepArr.map((item) => (
     <button
       key={item.value}
       className={cls(
         "group flex items-center justify-between rounded-2xl bg-background-200 px-8 py-5 transition-all hover:bg-orange-300",
-        currentStep === item.value ? "bg-orange-300" : ""
+        currentStep.value === item.value ? "bg-orange-300" : ""
       )}
       onClick={() => handleClickStep(item.value)}
     >
@@ -48,7 +44,9 @@ const StepButton = () => {
         <span
           className={cls(
             "flex size-7 items-center justify-center rounded-full bg-background-300 text-gray-200 transition-colors group-hover:bg-orange-50 group-hover:text-orange-300",
-            currentStep === item.value ? "bg-orange-50 text-orange-300" : ""
+            currentStep.value === item.value
+              ? "bg-orange-50 text-orange-300"
+              : ""
           )}
         >
           {item.step}
@@ -56,13 +54,13 @@ const StepButton = () => {
         <h2
           className={cls(
             "text-xl font-bold text-black-100 transition-colors group-hover:text-white",
-            currentStep === item.value ? "text-white" : ""
+            currentStep.value === item.value ? "text-white" : ""
           )}
         >
           {item.title}
         </h2>
       </div>
-      <WritingTag currentStep={currentStep} value={item.value} />
+      <WritingTag currentStep={currentStep.value} value={item.value} />
     </button>
   ));
 };

--- a/src/app/addform/components/Title.tsx
+++ b/src/app/addform/components/Title.tsx
@@ -5,13 +5,20 @@ import { useRouter } from "next/navigation";
 const Title = () => {
   const router = useRouter();
 
+  const handleCancel = () => {
+    const isConfirm = confirm("작성을 취소하시겠습니까?"); // 모달 변경 필요
+    if (isConfirm) {
+      router.push("/albalist/owner");
+    }
+  };
+
   return (
     <div className="flex w-full items-center justify-between p-6 pc:m-0 pc:w-[640px]">
       <h2 className="text-xl font-semibold text-black-500 pc:text-3xl">
         알바폼 만들기
       </h2>
       <button
-        onClick={() => router.push("/albalist/owner")}
+        onClick={handleCancel}
         className="rounded-lg bg-gray-100 px-3.5 py-2 text-md font-semibold text-white transition-colors hover:bg-orange-300 pc:text-xl"
       >
         작성 취소

--- a/src/app/addform/components/Title.tsx
+++ b/src/app/addform/components/Title.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+const Title = () => {
+  const router = useRouter();
+
+  return (
+    <div className="flex w-full items-center justify-between p-6 pc:m-0 pc:w-[640px]">
+      <h2 className="text-xl font-semibold text-black-500 pc:text-3xl">
+        알바폼 만들기
+      </h2>
+      <button
+        onClick={() => router.push("/albalist/owner")}
+        className="rounded-lg bg-gray-100 px-3.5 py-2 text-md font-semibold text-white transition-colors hover:bg-orange-300 pc:text-xl"
+      >
+        작성 취소
+      </button>
+    </div>
+  );
+};
+
+export default Title;

--- a/src/app/addform/layout.tsx
+++ b/src/app/addform/layout.tsx
@@ -5,7 +5,7 @@ export const metadata: Metadata = {
 };
 
 const AddFormLayout = ({ children }: { children: React.ReactNode }) => {
-  return <div className="ml-[148px] mt-10">{children}</div>;
+  return <div className="pc:ml-[148px] pc:mt-10">{children}</div>;
 };
 
 export default AddFormLayout;

--- a/src/app/addform/page.tsx
+++ b/src/app/addform/page.tsx
@@ -1,5 +1,7 @@
 import { AddFormStepProps } from "@/types/addform";
 import StepSidebar from "./components/StepSidebar";
+import Title from "./components/Title";
+import AlbaformCreateDropdown from "@/components/dropdown/AlbaformCreateDropdown";
 
 const mockTemporaryDataByStep: AddFormStepProps = {
   stepOne: {
@@ -33,9 +35,11 @@ const mockTemporaryDataByStep: AddFormStepProps = {
 
 const AddFormPage = async () => {
   return (
-    <>
+    <div className="m-auto flex w-[375px] flex-col space-y-3 pc:m-0 pc:w-full pc:flex-row pc:space-y-0">
       <StepSidebar temporaryDataByStep={mockTemporaryDataByStep} />
-    </>
+      <Title />
+      <AlbaformCreateDropdown />
+    </div>
   );
 };
 

--- a/src/app/addform/page.tsx
+++ b/src/app/addform/page.tsx
@@ -38,7 +38,9 @@ const AddFormPage = async () => {
     <div className="m-auto flex w-[375px] flex-col space-y-3 pc:m-0 pc:w-full pc:flex-row pc:space-y-0">
       <StepSidebar temporaryDataByStep={mockTemporaryDataByStep} />
       <Title />
-      <AlbaformCreateDropdown />
+      <div className="m-auto w-[327px]">
+        <AlbaformCreateDropdown />
+      </div>
     </div>
   );
 };

--- a/src/atoms/addFormAtom.ts
+++ b/src/atoms/addFormAtom.ts
@@ -1,3 +1,13 @@
 import { atom } from "jotai";
 
-export const addFormStepAtom = atom<string>("stepOne");
+interface AlbaformCreateStep {
+  title?: string;
+  value: string;
+  stepNum?: number;
+}
+
+export const addFormStepAtom = atom<AlbaformCreateStep>({
+  title: "모집 내용",
+  value: "stepOne",
+  stepNum: 1,
+});

--- a/src/components/dropdown/AlbaformCreateDropdown.tsx
+++ b/src/components/dropdown/AlbaformCreateDropdown.tsx
@@ -62,7 +62,7 @@ const AlbaformCreateDropdown = () => {
         id="albaformCreate"
         checkedValue={currentStep.value}
       >
-        <div className="group m-auto flex w-[327px] items-center justify-between rounded-2xl bg-orange-300 px-6 py-3">
+        <div className="group flex w-[327px] items-center justify-between rounded-2xl bg-orange-300 px-6 py-3">
           <div className="flex items-center space-x-3">
             <span className="flex size-5 items-center justify-center rounded-full bg-white text-md font-bold text-orange-300">
               {stepNum}

--- a/src/components/dropdown/AlbaformCreateDropdown.tsx
+++ b/src/components/dropdown/AlbaformCreateDropdown.tsx
@@ -37,7 +37,7 @@ const AlbaformCreateDropdown = () => {
     { title: "모집 조건", value: "stepTwo", stepNum: 2 },
     { title: "근무 조건", value: "stepThree", stepNum: 3 },
   ];
-  console.log(currentStep.value);
+
   return (
     <DropdownMenu className="pc:hidden">
       <DropdownMenuTrigger

--- a/src/components/dropdown/AlbaformCreateDropdown.tsx
+++ b/src/components/dropdown/AlbaformCreateDropdown.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { addFormStepAtom } from "@/atoms/addFormAtom";
 import { dropdownTriggerAtom } from "@/atoms/dropdownAtomStore";
 import {
   DropdownMenu,
@@ -7,46 +8,28 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/dropdown/DropdownMenu";
-import useViewPort from "@/hooks/useViewport";
-import { useAtomValue } from "jotai";
+import { useAtom, useAtomValue } from "jotai";
 import Image from "next/image";
-import { useEffect, useState } from "react";
-
-interface AlbaformCreateStep {
-  title: string;
-  value: string;
-}
+import { useEffect } from "react";
 
 // 알바폼 생성 컴포넌트 URL에서 albaformStep 값을 받아서 단계별 form을 표출하는데 사용하세요.
 const AlbaformCreateDropdown = () => {
-  const viewPort = useViewPort();
-  const [stepNum, setStepNum] = useState(1);
-  const [currentStep, setCurrentStep] = useState<AlbaformCreateStep>({
-    title: "모집 내용",
-    value: "stepOne",
-  });
+  const [currentStep, setCurrentStep] = useAtom(addFormStepAtom);
   const isOpen = useAtomValue(dropdownTriggerAtom("albaformCreate"));
 
   const updateURL = (value: string) => {
     const params = new URLSearchParams(window.location.search);
-    params.set("albaformStep", value);
+    params.set("step", value);
 
     window.history.pushState({}, "", `?${params}`);
   };
 
   useEffect(() => {
-    if (viewPort === "mobile" || viewPort === "tablet") {
-      updateURL(currentStep.value);
-    } else {
-      const params = new URLSearchParams(window.location.search);
-      params.delete("albaformStep");
-      window.history.pushState({}, "", `?${params}`);
-    }
-  }, [currentStep.value, viewPort]);
+    updateURL(currentStep.value);
+  }, [currentStep]);
 
   const handleClick = (value: string, stepNum: number, title: string) => {
-    setCurrentStep({ title, value });
-    setStepNum(stepNum);
+    setCurrentStep({ title, value, stepNum });
   };
 
   const itemArr = [
@@ -54,7 +37,7 @@ const AlbaformCreateDropdown = () => {
     { title: "모집 조건", value: "stepTwo", stepNum: 2 },
     { title: "근무 조건", value: "stepThree", stepNum: 3 },
   ];
-
+  console.log(currentStep.value);
   return (
     <DropdownMenu className="pc:hidden">
       <DropdownMenuTrigger
@@ -65,7 +48,7 @@ const AlbaformCreateDropdown = () => {
         <div className="group flex w-[327px] items-center justify-between rounded-2xl bg-orange-300 px-6 py-3">
           <div className="flex items-center space-x-3">
             <span className="flex size-5 items-center justify-center rounded-full bg-white text-md font-bold text-orange-300">
-              {stepNum}
+              {currentStep.stepNum}
             </span>
             <h2 className="text-md font-bold text-white">
               {currentStep.title}

--- a/src/components/dropdown/AlbaformCreateDropdown.tsx
+++ b/src/components/dropdown/AlbaformCreateDropdown.tsx
@@ -62,7 +62,7 @@ const AlbaformCreateDropdown = () => {
         id="albaformCreate"
         checkedValue={currentStep.value}
       >
-        <div className="group flex w-[327px] items-center justify-between rounded-2xl bg-orange-300 px-6 py-3">
+        <div className="group m-auto flex w-[327px] items-center justify-between rounded-2xl bg-orange-300 px-6 py-3">
           <div className="flex items-center space-x-3">
             <span className="flex size-5 items-center justify-center rounded-full bg-white text-md font-bold text-orange-300">
               {stepNum}


### PR DESCRIPTION
## 🧩 이슈 번호 #171 

## 🔎 작업 내용
<!-- - 기능에서 어떤 부분이 구현되었는지 설명해주세요. -->
- 알바폼 만들기 페이지의 타이틀에 있는 작성취소 버튼을 추가했습니다.
- 경고창에서 "예"를 누르면 사장님용 알바목록으로 갈 수 있습니다.

## 이미지 첨부
<!-- preview 이미지 혹 동영상을 첨부해주세요. -->
![작업](https://github.com/user-attachments/assets/312deb86-1ce4-4403-983d-f4f9bc12fa22)

## 🔧 앞으로의 과제

<!-- - 이번 이슈에서 앞으로 남은 할 일을 적어주세요. -->
- 알바폼 만들기 1단계
- 스키마 분기처리 및 검증로직

## 👩‍💻 공유 포인트 및 논의 사항

<!-- 공유하거나 논의할 사항을 작성해주세요. -->
- 만들어둔 드롭다운까지 포함했습니다.
- PC에서는 버튼식, 태블릿부터는 드롭다운이라 화면이 반응형에서 전환이 되더라도 단계가 따로따로 진행되지 않도록 했습니다.
- URL 파라미터 키 이름을 step으로 일원화했습니다.
