### PR TITLE
Feat: 알바폼 만들기 페이지 zod 스키마 검증 및 단계별 분기처리 세팅

### DIFF
--- a/src/app/addform/components/StepButton.tsx
+++ b/src/app/addform/components/StepButton.tsx
@@ -1,4 +1,3 @@
-import useViewPort from "@/hooks/useViewport";
 import { cls } from "@/utils/dynamicTailwinds";
 import { useEffect } from "react";
 import WritingTag from "./WritingTag";
@@ -6,7 +5,6 @@ import { addFormStepAtom } from "@/atoms/addFormAtom";
 import { useAtom } from "jotai";
 
 const StepButton = () => {
-  const viewport = useViewPort();
   const [currentStep, setCurrentStep] = useAtom(addFormStepAtom);
   const stepArr = [
     { title: "모집 내용", step: 1, value: "stepOne" },
@@ -21,26 +19,24 @@ const StepButton = () => {
   };
 
   const handleClickStep = (value: string) => {
-    setCurrentStep(value);
+    setCurrentStep({
+      title: stepArr.find((item) => item.value === value)?.title,
+      value,
+      stepNum: stepArr.find((item) => item.value === value)?.step,
+    });
     updateURL(value);
   };
 
   useEffect(() => {
-    if (viewport === "pc") {
-      updateURL(currentStep);
-    } else {
-      const params = new URLSearchParams(window.location.search);
-      params.delete("step");
-      window.history.pushState({}, "", `?${params}`);
-    }
-  }, [currentStep, viewport]);
+    updateURL(currentStep.value);
+  }, [currentStep]);
 
   return stepArr.map((item) => (
     <button
       key={item.value}
       className={cls(
         "group flex items-center justify-between rounded-2xl bg-background-200 px-8 py-5 transition-all hover:bg-orange-300",
-        currentStep === item.value ? "bg-orange-300" : ""
+        currentStep.value === item.value ? "bg-orange-300" : ""
       )}
       onClick={() => handleClickStep(item.value)}
     >
@@ -48,7 +44,9 @@ const StepButton = () => {
         <span
           className={cls(
             "flex size-7 items-center justify-center rounded-full bg-background-300 text-gray-200 transition-colors group-hover:bg-orange-50 group-hover:text-orange-300",
-            currentStep === item.value ? "bg-orange-50 text-orange-300" : ""
+            currentStep.value === item.value
+              ? "bg-orange-50 text-orange-300"
+              : ""
           )}
         >
           {item.step}
@@ -56,13 +54,13 @@ const StepButton = () => {
         <h2
           className={cls(
             "text-xl font-bold text-black-100 transition-colors group-hover:text-white",
-            currentStep === item.value ? "text-white" : ""
+            currentStep.value === item.value ? "text-white" : ""
           )}
         >
           {item.title}
         </h2>
       </div>
-      <WritingTag currentStep={currentStep} value={item.value} />
+      <WritingTag currentStep={currentStep.value} value={item.value} />
     </button>
   ));
 };

--- a/src/app/addform/components/StepContainer.tsx
+++ b/src/app/addform/components/StepContainer.tsx
@@ -8,6 +8,7 @@ import StepThreeContents from "./StepThreeContents";
 import { z } from "zod";
 import { useForm } from "react-hook-form";
 import { useSearchParams } from "next/navigation";
+import { Fragment } from "react";
 
 const StepContainer = () => {
   const searchParams = useSearchParams();
@@ -54,15 +55,11 @@ const StepContainer = () => {
   return (
     <form className="p-6">
       {compoentsByStepArr.map((component) => (
-        <>
+        <Fragment key={component.step}>
           {step === component.step && (
-            <component.component
-              key={component.step}
-              register={register}
-              errors={errors}
-            />
+            <component.component register={register} errors={errors} />
           )}
-        </>
+        </Fragment>
       ))}
     </form>
   );

--- a/src/app/addform/components/StepContainer.tsx
+++ b/src/app/addform/components/StepContainer.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { addFormSchema } from "@/schema/addForm/addFormSchema";
+import StepOneContents from "./StepOneContents";
+import StepTwoContents from "./StepTwoContents";
+import StepThreeContents from "./StepThreeContents";
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { useSearchParams } from "next/navigation";
+
+const StepContainer = () => {
+  const searchParams = useSearchParams();
+  const step = searchParams.get("step");
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    watch,
+    setValue,
+    formState: { errors, isValid, isSubmitting },
+  } = useForm<z.infer<typeof addFormSchema>>({
+    resolver: zodResolver(addFormSchema),
+    mode: "onChange",
+    defaultValues: {
+      title: "",
+      description: "",
+      recruitmentStartDate: "",
+      recruitmentEndDate: "",
+      numberOfPositions: 0,
+      gender: "",
+      education: "",
+      age: "",
+      preferred: "",
+      location: "",
+      workStartDate: "",
+      workEndDate: "",
+      workStartTime: "",
+      workEndTime: "",
+      workDays: [],
+      isNegotiableWorkDays: false,
+      hourlyWage: 0,
+      isPublic: false,
+    },
+  });
+
+  const compoentsByStepArr = [
+    { step: "stepOne", component: StepOneContents },
+    { step: "stepTwo", component: StepTwoContents },
+    { step: "stepThree", component: StepThreeContents },
+  ];
+
+  return (
+    <form className="p-6">
+      {compoentsByStepArr.map((component) => (
+        <>
+          {step === component.step && (
+            <component.component
+              key={component.step}
+              register={register}
+              errors={errors}
+            />
+          )}
+        </>
+      ))}
+    </form>
+  );
+};
+
+export default StepContainer;

--- a/src/app/addform/components/StepOneContents.tsx
+++ b/src/app/addform/components/StepOneContents.tsx
@@ -1,0 +1,14 @@
+import { addFormSchema } from "@/schema/addForm/addFormSchema";
+import { UseFormRegister, FieldErrors } from "react-hook-form";
+import { z } from "zod";
+
+interface StepOneContentsProps {
+  register: UseFormRegister<z.infer<typeof addFormSchema>>;
+  errors: FieldErrors<z.infer<typeof addFormSchema>>;
+}
+
+const StepOneContents = ({ register, errors }: StepOneContentsProps) => {
+  return <div>StepOneContents</div>;
+};
+
+export default StepOneContents;

--- a/src/app/addform/components/StepThreeContents.tsx
+++ b/src/app/addform/components/StepThreeContents.tsx
@@ -1,0 +1,14 @@
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+import { addFormSchema } from "@/schema/addForm/addFormSchema";
+import { z } from "zod";
+
+interface StepThreeContentsProps {
+  register: UseFormRegister<z.infer<typeof addFormSchema>>;
+  errors: FieldErrors<z.infer<typeof addFormSchema>>;
+}
+
+const StepThreeContents = ({ register, errors }: StepThreeContentsProps) => {
+  return <div>StepThreeContents</div>;
+};
+
+export default StepThreeContents;

--- a/src/app/addform/components/StepTwoContents.tsx
+++ b/src/app/addform/components/StepTwoContents.tsx
@@ -1,0 +1,14 @@
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+import { addFormSchema } from "@/schema/addForm/addFormSchema";
+import { z } from "zod";
+
+interface StepTwoContentsProps {
+  register: UseFormRegister<z.infer<typeof addFormSchema>>;
+  errors: FieldErrors<z.infer<typeof addFormSchema>>;
+}
+
+const StepTwoContents = ({ register, errors }: StepTwoContentsProps) => {
+  return <div>StepTwoContents</div>;
+};
+
+export default StepTwoContents;

--- a/src/app/addform/components/Title.tsx
+++ b/src/app/addform/components/Title.tsx
@@ -5,13 +5,20 @@ import { useRouter } from "next/navigation";
 const Title = () => {
   const router = useRouter();
 
+  const handleCancel = () => {
+    const isConfirm = confirm("작성을 취소하시겠습니까?"); // 모달 변경 필요
+    if (isConfirm) {
+      router.push("/albalist/owner");
+    }
+  };
+
   return (
     <div className="flex w-full items-center justify-between p-6 pc:m-0 pc:w-[640px]">
       <h2 className="text-xl font-semibold text-black-500 pc:text-3xl">
         알바폼 만들기
       </h2>
       <button
-        onClick={() => router.push("/albalist/owner")}
+        onClick={handleCancel}
         className="rounded-lg bg-gray-100 px-3.5 py-2 text-md font-semibold text-white transition-colors hover:bg-orange-300 pc:text-xl"
       >
         작성 취소

--- a/src/app/addform/components/Title.tsx
+++ b/src/app/addform/components/Title.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+const Title = () => {
+  const router = useRouter();
+
+  return (
+    <div className="flex w-full items-center justify-between p-6 pc:m-0 pc:w-[640px]">
+      <h2 className="text-xl font-semibold text-black-500 pc:text-3xl">
+        알바폼 만들기
+      </h2>
+      <button
+        onClick={() => router.push("/albalist/owner")}
+        className="rounded-lg bg-gray-100 px-3.5 py-2 text-md font-semibold text-white transition-colors hover:bg-orange-300 pc:text-xl"
+      >
+        작성 취소
+      </button>
+    </div>
+  );
+};
+
+export default Title;

--- a/src/app/addform/layout.tsx
+++ b/src/app/addform/layout.tsx
@@ -5,7 +5,7 @@ export const metadata: Metadata = {
 };
 
 const AddFormLayout = ({ children }: { children: React.ReactNode }) => {
-  return <div className="ml-[148px] mt-10">{children}</div>;
+  return <div className="pc:ml-[148px] pc:mt-10">{children}</div>;
 };
 
 export default AddFormLayout;

--- a/src/app/addform/page.tsx
+++ b/src/app/addform/page.tsx
@@ -1,5 +1,7 @@
 import { AddFormStepProps } from "@/types/addform";
 import StepSidebar from "./components/StepSidebar";
+import Title from "./components/Title";
+import AlbaformCreateDropdown from "@/components/dropdown/AlbaformCreateDropdown";
 
 const mockTemporaryDataByStep: AddFormStepProps = {
   stepOne: {
@@ -33,9 +35,11 @@ const mockTemporaryDataByStep: AddFormStepProps = {
 
 const AddFormPage = async () => {
   return (
-    <>
+    <div className="m-auto flex w-[375px] flex-col space-y-3 pc:m-0 pc:w-full pc:flex-row pc:space-y-0">
       <StepSidebar temporaryDataByStep={mockTemporaryDataByStep} />
-    </>
+      <Title />
+      <AlbaformCreateDropdown />
+    </div>
   );
 };
 

--- a/src/app/addform/page.tsx
+++ b/src/app/addform/page.tsx
@@ -3,6 +3,7 @@ import StepSidebar from "./components/StepSidebar";
 import Title from "./components/Title";
 import AlbaformCreateDropdown from "@/components/dropdown/AlbaformCreateDropdown";
 import StepContainer from "./components/StepContainer";
+import { Suspense } from "react";
 
 const mockTemporaryDataByStep: AddFormStepProps = {
   stepOne: {
@@ -43,7 +44,15 @@ const AddFormPage = () => {
         <div className="m-auto w-[327px] pc:hidden">
           <AlbaformCreateDropdown />
         </div>
-        <StepContainer />
+        <Suspense
+          fallback={
+            <div className="text-center text-md text-black-500 pc:text-xl">
+              잠시만 기다려주세요...
+            </div>
+          }
+        >
+          <StepContainer />
+        </Suspense>
       </div>
     </div>
   );

--- a/src/app/addform/page.tsx
+++ b/src/app/addform/page.tsx
@@ -2,6 +2,7 @@ import { AddFormStepProps } from "@/types/addform";
 import StepSidebar from "./components/StepSidebar";
 import Title from "./components/Title";
 import AlbaformCreateDropdown from "@/components/dropdown/AlbaformCreateDropdown";
+import StepContainer from "./components/StepContainer";
 
 const mockTemporaryDataByStep: AddFormStepProps = {
   stepOne: {
@@ -33,13 +34,16 @@ const mockTemporaryDataByStep: AddFormStepProps = {
   },
 };
 
-const AddFormPage = async () => {
+const AddFormPage = () => {
   return (
     <div className="m-auto flex w-[375px] flex-col space-y-3 pc:m-0 pc:w-full pc:flex-row pc:space-y-0">
       <StepSidebar temporaryDataByStep={mockTemporaryDataByStep} />
-      <Title />
-      <div className="m-auto w-[327px]">
-        <AlbaformCreateDropdown />
+      <div className="flex flex-col">
+        <Title />
+        <div className="m-auto w-[327px] pc:hidden">
+          <AlbaformCreateDropdown />
+        </div>
+        <StepContainer />
       </div>
     </div>
   );

--- a/src/app/addform/page.tsx
+++ b/src/app/addform/page.tsx
@@ -38,7 +38,9 @@ const AddFormPage = async () => {
     <div className="m-auto flex w-[375px] flex-col space-y-3 pc:m-0 pc:w-full pc:flex-row pc:space-y-0">
       <StepSidebar temporaryDataByStep={mockTemporaryDataByStep} />
       <Title />
-      <AlbaformCreateDropdown />
+      <div className="m-auto w-[327px]">
+        <AlbaformCreateDropdown />
+      </div>
     </div>
   );
 };

--- a/src/atoms/addFormAtom.ts
+++ b/src/atoms/addFormAtom.ts
@@ -1,3 +1,13 @@
 import { atom } from "jotai";
 
-export const addFormStepAtom = atom<string>("stepOne");
+interface AlbaformCreateStep {
+  title?: string;
+  value: string;
+  stepNum?: number;
+}
+
+export const addFormStepAtom = atom<AlbaformCreateStep>({
+  title: "모집 내용",
+  value: "stepOne",
+  stepNum: 1,
+});

--- a/src/components/dropdown/AlbaformCreateDropdown.tsx
+++ b/src/components/dropdown/AlbaformCreateDropdown.tsx
@@ -62,7 +62,7 @@ const AlbaformCreateDropdown = () => {
         id="albaformCreate"
         checkedValue={currentStep.value}
       >
-        <div className="group m-auto flex w-[327px] items-center justify-between rounded-2xl bg-orange-300 px-6 py-3">
+        <div className="group flex w-[327px] items-center justify-between rounded-2xl bg-orange-300 px-6 py-3">
           <div className="flex items-center space-x-3">
             <span className="flex size-5 items-center justify-center rounded-full bg-white text-md font-bold text-orange-300">
               {stepNum}

--- a/src/components/dropdown/AlbaformCreateDropdown.tsx
+++ b/src/components/dropdown/AlbaformCreateDropdown.tsx
@@ -37,7 +37,7 @@ const AlbaformCreateDropdown = () => {
     { title: "모집 조건", value: "stepTwo", stepNum: 2 },
     { title: "근무 조건", value: "stepThree", stepNum: 3 },
   ];
-  console.log(currentStep.value);
+
   return (
     <DropdownMenu className="pc:hidden">
       <DropdownMenuTrigger

--- a/src/components/dropdown/AlbaformCreateDropdown.tsx
+++ b/src/components/dropdown/AlbaformCreateDropdown.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { addFormStepAtom } from "@/atoms/addFormAtom";
 import { dropdownTriggerAtom } from "@/atoms/dropdownAtomStore";
 import {
   DropdownMenu,
@@ -7,46 +8,28 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/dropdown/DropdownMenu";
-import useViewPort from "@/hooks/useViewport";
-import { useAtomValue } from "jotai";
+import { useAtom, useAtomValue } from "jotai";
 import Image from "next/image";
-import { useEffect, useState } from "react";
-
-interface AlbaformCreateStep {
-  title: string;
-  value: string;
-}
+import { useEffect } from "react";
 
 // 알바폼 생성 컴포넌트 URL에서 albaformStep 값을 받아서 단계별 form을 표출하는데 사용하세요.
 const AlbaformCreateDropdown = () => {
-  const viewPort = useViewPort();
-  const [stepNum, setStepNum] = useState(1);
-  const [currentStep, setCurrentStep] = useState<AlbaformCreateStep>({
-    title: "모집 내용",
-    value: "stepOne",
-  });
+  const [currentStep, setCurrentStep] = useAtom(addFormStepAtom);
   const isOpen = useAtomValue(dropdownTriggerAtom("albaformCreate"));
 
   const updateURL = (value: string) => {
     const params = new URLSearchParams(window.location.search);
-    params.set("albaformStep", value);
+    params.set("step", value);
 
     window.history.pushState({}, "", `?${params}`);
   };
 
   useEffect(() => {
-    if (viewPort === "mobile" || viewPort === "tablet") {
-      updateURL(currentStep.value);
-    } else {
-      const params = new URLSearchParams(window.location.search);
-      params.delete("albaformStep");
-      window.history.pushState({}, "", `?${params}`);
-    }
-  }, [currentStep.value, viewPort]);
+    updateURL(currentStep.value);
+  }, [currentStep]);
 
   const handleClick = (value: string, stepNum: number, title: string) => {
-    setCurrentStep({ title, value });
-    setStepNum(stepNum);
+    setCurrentStep({ title, value, stepNum });
   };
 
   const itemArr = [
@@ -54,7 +37,7 @@ const AlbaformCreateDropdown = () => {
     { title: "모집 조건", value: "stepTwo", stepNum: 2 },
     { title: "근무 조건", value: "stepThree", stepNum: 3 },
   ];
-
+  console.log(currentStep.value);
   return (
     <DropdownMenu className="pc:hidden">
       <DropdownMenuTrigger
@@ -65,7 +48,7 @@ const AlbaformCreateDropdown = () => {
         <div className="group flex w-[327px] items-center justify-between rounded-2xl bg-orange-300 px-6 py-3">
           <div className="flex items-center space-x-3">
             <span className="flex size-5 items-center justify-center rounded-full bg-white text-md font-bold text-orange-300">
-              {stepNum}
+              {currentStep.stepNum}
             </span>
             <h2 className="text-md font-bold text-white">
               {currentStep.title}

--- a/src/components/dropdown/AlbaformCreateDropdown.tsx
+++ b/src/components/dropdown/AlbaformCreateDropdown.tsx
@@ -62,7 +62,7 @@ const AlbaformCreateDropdown = () => {
         id="albaformCreate"
         checkedValue={currentStep.value}
       >
-        <div className="group flex w-[327px] items-center justify-between rounded-2xl bg-orange-300 px-6 py-3">
+        <div className="group m-auto flex w-[327px] items-center justify-between rounded-2xl bg-orange-300 px-6 py-3">
           <div className="flex items-center space-x-3">
             <span className="flex size-5 items-center justify-center rounded-full bg-white text-md font-bold text-orange-300">
               {stepNum}

--- a/src/schema/addForm/addFormSchema.ts
+++ b/src/schema/addForm/addFormSchema.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+
+const htmlRegex = /(<([^>]+)>)/gi;
+const xssRegex = /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi;
+const sqlInjectionRegex =
+  /(\b(SELECT|INSERT|UPDATE|DELETE|DROP|--|#|\/\*|\*\/)\b)/i;
+
+export const addFormSchema = z.object({
+  title: z
+    .string()
+    .min(1, { message: "제목을 입력해주세요." })
+    .regex(/([A-Za-zㄱ-ㅎ가-힣0-9])/, {
+      message: "제목에 특수문자는 사용할 수 없습니다.",
+    })
+    .trim(),
+  description: z
+    .string()
+    .min(1, { message: "내용을 입력해주세요." })
+    .max(200, { message: "내용은 200자 이상 입력할 수 없습니다." })
+    .regex(htmlRegex || xssRegex || sqlInjectionRegex, {
+      message: "특정 특수문자는 사용할 수 없습니다.",
+    })
+    .trim(),
+  recruitmentStartDate: z
+    .string()
+    .min(1, { message: "모집 시작일을 입력해주세요." }),
+  recruitmentEndDate: z
+    .string()
+    .min(1, { message: "모집 종료일을 입력해주세요." }),
+  numberOfPositions: z
+    .number()
+    .min(1, { message: "모집 인원을 입력해주세요." }),
+  gender: z.string().min(1, { message: "성별을 선택해주세요." }),
+  education: z.string().min(1, { message: "학력을 선택해주세요." }),
+  age: z.string().min(1, { message: "연령대를 선택해주세요." }),
+  preferred: z.string().min(1, { message: "우대사항을 선택해주세요." }),
+  location: z.string().min(1, { message: "근무지를 입력해주세요." }).trim(),
+  workStartDate: z.string().min(1, { message: "근무 시작일을 선택해주세요." }),
+  workEndDate: z.string().min(1, { message: "근무 종료일을 선택해주세요." }),
+  workStartTime: z
+    .string()
+    .min(1, { message: "근무 시작시간을 선택해주세요." }),
+  workEndTime: z.string().min(1, { message: "근무 종료시간을 선택해주세요." }),
+  workDays: z.array(z.string()).min(1, { message: "근무요일을 선택해주세요." }),
+  isNegotiableWorkDays: z.boolean(),
+  hourlyWage: z.number().min(1, { message: "시급을 입력해주세요." }),
+  isPublic: z.boolean(),
+});


### PR DESCRIPTION
## 🧩 이슈 번호 #170 

## 🔎 작업 내용
<!-- - 기능에서 어떤 부분이 구현되었는지 설명해주세요. -->
- 알바폼 만들기 페이지에서 사용할 서버전달용 zod 스키마를 추가했습니다.
- 검증로직도 포함한 상태입니다.
- 단계별 form을 만들고 해당 단계에 맞는 register와 errors를 가져와 입력받을 수 있도록 세팅해놨습니다.
- 다른 팀원님이 오시면 form 만들고 세팅해둔 register와 errors를 가지고 각 input 요소에 적용해주시면 됩니다.

## 이미지 첨부
<!-- preview 이미지 혹 동영상을 첨부해주세요. -->
![조드](https://github.com/user-attachments/assets/00766e51-6194-4044-848a-b23bbe4f857b)

## 🔧 앞으로의 과제

<!-- - 이번 이슈에서 앞으로 남은 할 일을 적어주세요. -->
- 1단계 form 작업

## 👩‍💻 공유 포인트 및 논의 사항

<!-- 공유하거나 논의할 사항을 작성해주세요. -->
- form을 만들며 알바폼 만들기 페이지가 진행되면서 일부 zod 스키마와 정규식이 변경될 수 있습니다.
- imageUrls는 별도 이미지 업로드 관련 로직을 만들어야 해서 스키마에 넣지 않았습니다.
- 이미지 관련 로직 작업 후 zod 스키마에 imageUrls 넣을 것으로 예상은 되는데, 작업하면서 고려해보겠습니다.
