### PR TITLE
Fix: URL 파라미터가 있을 때 뒤로가기 시 파라미터 초기화 및 이전페이지 이동

### DIFF
--- a/src/app/addform/components/Title.tsx
+++ b/src/app/addform/components/Title.tsx
@@ -8,7 +8,7 @@ const Title = () => {
   const handleCancel = () => {
     const isConfirm = confirm("작성을 취소하시겠습니까?"); // 모달 변경 필요
     if (isConfirm) {
-      router.push("/albalist/owner");
+      router.push("/albalist");
     }
   };
 

--- a/src/components/dropdown/AlbaformCreateDropdown.tsx
+++ b/src/components/dropdown/AlbaformCreateDropdown.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/dropdown/DropdownMenu";
+import { usePrevPage } from "@/hooks/usePrevPage";
 import { useAtom, useAtomValue } from "jotai";
 import Image from "next/image";
 import { useEffect } from "react";
@@ -16,6 +17,7 @@ import { useEffect } from "react";
 const AlbaformCreateDropdown = () => {
   const [currentStep, setCurrentStep] = useAtom(addFormStepAtom);
   const isOpen = useAtomValue(dropdownTriggerAtom("albaformCreate"));
+  usePrevPage();
 
   const updateURL = (value: string) => {
     const params = new URLSearchParams(window.location.search);

--- a/src/components/dropdown/AlbatalkFilterDropdown.tsx
+++ b/src/components/dropdown/AlbatalkFilterDropdown.tsx
@@ -6,6 +6,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/dropdown/DropdownMenu";
+import { usePrevPage } from "@/hooks/usePrevPage";
 import Image from "next/image";
 import { useEffect, useState } from "react";
 
@@ -21,6 +22,7 @@ const AlbatalkFilterDropdown = () => {
     title: "최신 순",
     value: "mostRecent",
   });
+  usePrevPage();
 
   const updateURL = (value: string) => {
     const params = new URLSearchParams(window.location.search);

--- a/src/components/dropdown/ApplicationDropdown.tsx
+++ b/src/components/dropdown/ApplicationDropdown.tsx
@@ -6,6 +6,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/dropdown/DropdownMenu";
+import { usePrevPage } from "@/hooks/usePrevPage";
 import { useState } from "react";
 
 // isRecruiting 값을 URL에서 추출하여 서버로 전달하세요.
@@ -13,6 +14,7 @@ const ApplicationDropdown = () => {
   const [isRecruiting, setIsRecruiting] = useState<boolean | undefined>(
     undefined
   );
+  usePrevPage();
 
   const handleClick = (status: boolean | undefined) => {
     setIsRecruiting(status);

--- a/src/components/dropdown/OrderByDropdown.tsx
+++ b/src/components/dropdown/OrderByDropdown.tsx
@@ -6,6 +6,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/dropdown/DropdownMenu";
+import { usePrevPage } from "@/hooks/usePrevPage";
 import Image from "next/image";
 import { useEffect, useState } from "react";
 
@@ -21,6 +22,7 @@ const OrderByDropdown = () => {
     title: "최신 순",
     value: "mostRecent",
   });
+  usePrevPage();
 
   const updateURL = (value: string) => {
     const params = new URLSearchParams(window.location.search);

--- a/src/components/dropdown/PublicDropdown.tsx
+++ b/src/components/dropdown/PublicDropdown.tsx
@@ -6,11 +6,13 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/dropdown/DropdownMenu";
+import { usePrevPage } from "@/hooks/usePrevPage";
 import { useState } from "react";
 
 // isPublic 값을 URL에서 추출하여 서버로 전달하세요.
 const PublicDropdown = () => {
   const [isPublic, setIsPublic] = useState<boolean | undefined>(undefined);
+  usePrevPage();
 
   const handleClick = (status: boolean | undefined) => {
     setIsPublic(status);

--- a/src/components/dropdown/RecruitDropdown.tsx
+++ b/src/components/dropdown/RecruitDropdown.tsx
@@ -6,10 +6,13 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/dropdown/DropdownMenu";
+import { usePrevPage } from "@/hooks/usePrevPage";
 import { useState } from "react";
 
 // status 값을 URL에서 추출하여 서버로 전달하세요.
 const RecruitDropdown = () => {
+  usePrevPage();
+
   const [recruitStatus, setRecruitStatus] = useState<string | undefined>(
     undefined
   );

--- a/src/hooks/usePrevPage.ts
+++ b/src/hooks/usePrevPage.ts
@@ -1,0 +1,22 @@
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+// 뒤로가기 시 쿼리 파라미터 삭제 후 이전페이지로 이동
+export const usePrevPage = () => {
+  const router = useRouter();
+
+  useEffect(() => {
+    const handlePopState = () => {
+      const url = new URL(window.location.href);
+      url.search = "";
+      window.history.replaceState({}, "", url.toString());
+      router.back();
+    };
+
+    window.addEventListener("popstate", handlePopState);
+
+    return () => {
+      window.removeEventListener("popstate", handlePopState);
+    };
+  }, [router]);
+};


### PR DESCRIPTION
## 🧩 이슈 번호 #188 

## 🔎 작업 내용
<!-- - 기능에서 어떤 부분이 구현되었는지 설명해주세요. -->
- URL의 파라미터를 이용하는 페이지에서 사용자가 이전페이지로 가려고할 때 파라미터 초기화 후 이전에 사용자가 있었던 페이지로 이동하도록 했습니다.

## 이미지 첨부
<!-- preview 이미지 혹 동영상을 첨부해주세요. -->

https://github.com/user-attachments/assets/874bbdb4-48af-4c9c-afe5-eb2a56499a80

## 🔧 앞으로의 과제

<!-- - 이번 이슈에서 앞으로 남은 할 일을 적어주세요. -->
- 알바폼 만들기 페이지 1단계 form 작업

## 👩‍💻 공유 포인트 및 논의 사항

<!-- 공유하거나 논의할 사항을 작성해주세요. -->
