### PR TITLE
Chore: 지원하기 폼 벨리데이션 수정

### DIFF
--- a/src/schema/apply/applySchema.ts
+++ b/src/schema/apply/applySchema.ts
@@ -5,20 +5,27 @@ export const applySchema = z.object({
   phoneNumber: z.string().regex(/^(|010|011|016|017|018|019)\d{7,8}$/, {
     message: "올바르지 않은 번호입니다.",
   }),
-  experienceMonths: z.string(),
-  resumeName: z.string(),
+  experienceMonths: z
+    .string()
+    .regex(/^\d+$/, { message: "숫자(정수)만 입력해주세요." })
+    .refine((value) => parseInt(value, 10) <= 600, {
+      message: "최대 600개월까지 입력 가능합니다.",
+    }),
+
+  resumeName: z.string().regex(/\.(pdf|word)$/, {
+    message: "허용되는 파일 형식은 pdf, word 입니다.",
+  }),
   introduction: z
     .string()
     .min(1, { message: "자기 소개를 입력해주세요." })
-    .max(200, { message: "200자 이내로 입력해주세요." }),
+    .max(200, { message: "200자 이내로 입력해주세요." })
+    .regex(/([A-Za-zㄱ-ㅎ가-힣0-9!@#$%^&*()_+={}\[\]:;"'<>,.?\/`~\\|-])/, {
+      message: "해당 기호는 사용할 수 없습니다.",
+    })
+    .trim(),
   password: z
     .string()
+    .min(4, { message: "비밀번호 4자 이상 입력해주세요." })
     .max(12, { message: "비밀번호는 12자 이내여야합니다." })
-    .regex(
-      /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!\"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~]).{7,}$/,
-      {
-        message: "특수문자, 문자, 숫자 포함 7자 이상 입력해주세요.",
-      }
-    )
     .trim(),
 });


### PR DESCRIPTION
## 🧩 이슈 번호 #193 

## 🔎 작업 내용
applySchema 수정하였습니다.
 1. password : 4자 이상 12자 이하
 2.  experienceMonths (경력) : 숫자(정수) 만 가능, 600개월까지 가능
 3. resumeName(이력서) : 허용 파일 pdf, word 만 가능

## 이미지 첨부
![screencapture-localhost-3000-apply-1-2024-12-09-15_31_52](https://github.com/user-attachments/assets/b147aa53-ba5d-422c-a31d-0e8890e6fefb)

## 🔧 앞으로의 과제
지원하기 폼 기능 구현
1. 이력서 제출 기능
2. 폼 제출 기능

## 👩‍💻 공유 포인트 및 논의 사항

패스워드 유효성 검사 에러 메세지를 수정하여 "*지원내역 확인에 사용됩니다." 라는 문구와 겹치지 않게 하였습니다.
