### PR TITLE
Feat: 알바폼상세페이지 모집마감 모달기능

### DIFF
--- a/src/app/alba/[formId]/components/NoticeIsClosed.tsx
+++ b/src/app/alba/[formId]/components/NoticeIsClosed.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { useEffect } from "react";
+import { useModal } from "@/hooks/useModal";
+import isPast from "@/utils/isPast";
+
+const NoticeIsClosed = ({ closedDate }: { closedDate: string }) => {
+  const { openModal } = useModal();
+
+  useEffect(() => {
+    console.log(isPast(closedDate));
+
+    if (isPast(closedDate)) openModal("ClosedAlbaformModal");
+  }, [openModal, closedDate]);
+
+  return null;
+};
+
+export default NoticeIsClosed;

--- a/src/app/alba/[formId]/page.tsx
+++ b/src/app/alba/[formId]/page.tsx
@@ -8,6 +8,7 @@ import SimpleRequirements from "./components/SimpleRequirements";
 import EmployerInfo from "./components/EmployerInfo";
 import DetailRequirements from "./components/DetailRequirements";
 import NoticeApplicant from "./components/NoticeApplicant";
+import NoticeIsClosed from "./components/NoticeIsClosed";
 import { PageProps } from "../../../../.next/types/app/page";
 import { AlbaformDetailData } from "@/types/alba";
 
@@ -60,6 +61,7 @@ const AlbarformDetailPage = async ({ params }: PageProps) => {
         </section>
       </div>
       <NoticeApplicant count={data.applyCount} />
+      <NoticeIsClosed closedDate={data.recruitmentEndDate} />
     </>
   );
 };

--- a/src/utils/isPast.ts
+++ b/src/utils/isPast.ts
@@ -3,7 +3,7 @@ const isPast = (isoDateString: string) => {
 
   const targetDate = new Date(isoDateString);
 
-  return targetDate > currentDate;
+  return targetDate < currentDate;
 };
 
 export default isPast;


### PR DESCRIPTION
## 🧩 이슈 번호 #34 

## 🔎 작업 내용
- 알바폼 상세 페이지 들어갔을 때 모집기한이 지났다면 "마감 모달"이 뜨게끔 함.
- 컴포넌트 이름은 NoticeIsClosed, useEffect를 쓰고 useModal 커스텀훅을 호출하기 떄문에 use client 선언
- 페이지 컴포넌트에서는 data를 받아와 data.recruitmentEndDate를 인자로 전달

## 이미지 첨부

https://github.com/user-attachments/assets/6ea6397c-3c5f-4a74-81c4-e53d4b3cdbfe

## 🔧 앞으로의 과제
- "모집 마감 모달"이 렌더링 된 화면에서 X 누르고 껐을 때 지원하기 버튼이 기능하면 안되기에 눌렀을 때 모달이 다시 뜨게 하는 기능 추가해야 함.

