### PR TITLE
Feat:  알바폼상세페이지 내 지원 내역 보기/지원하기 버튼 기능 활성화

### DIFF
--- a/src/app/alba/[formId]/components/ApllicantActionButtons.tsx
+++ b/src/app/alba/[formId]/components/ApllicantActionButtons.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import SolidButton from "@/components/button/SolidButton";
+import { useModal } from "@/hooks/useModal";
+import { useRouter } from "next/navigation";
+
+const ApllicantActionButtons = ({ formId }: { formId: string }) => {
+  const router = useRouter();
+  const { openModal } = useModal();
+
+  return (
+    <>
+      <SolidButton
+        icon="/icon/write-fill-md.svg"
+        style="orange300"
+        onClick={() => router.push(`/apply/${formId}`)}
+      >
+        지원하기
+      </SolidButton>
+      <SolidButton
+        icon="/icon/document-md.svg"
+        style="outOrange300"
+        onClick={() => openModal("GetMyApplicationModal")}
+      >
+        내 지원 내역 보기
+      </SolidButton>
+    </>
+  );
+};
+
+export default ApllicantActionButtons;

--- a/src/app/alba/[formId]/components/ApllicantActionButtons.tsx
+++ b/src/app/alba/[formId]/components/ApllicantActionButtons.tsx
@@ -1,21 +1,37 @@
 "use client";
 
+import isPast from "@/utils/isPast";
 import SolidButton from "@/components/button/SolidButton";
 import { useModal } from "@/hooks/useModal";
 import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
 
-const ApllicantActionButtons = ({ formId }: { formId: string }) => {
+type ApllicantActionButtonsProps = {
+  formId: string;
+  recruitmentEndDate: string;
+};
+
+const ApllicantActionButtons = ({
+  formId,
+  recruitmentEndDate,
+}: ApllicantActionButtonsProps) => {
+  const [disabled, setDisabled] = useState(false);
   const router = useRouter();
   const { openModal } = useModal();
+
+  useEffect(() => {
+    if (isPast(recruitmentEndDate)) setDisabled(true);
+  }, [recruitmentEndDate]);
 
   return (
     <>
       <SolidButton
-        icon="/icon/write-fill-md.svg"
-        style="orange300"
+        icon={disabled ? "" : "/icon/write-fill-md.svg"}
+        style={disabled ? "gray100" : "orange300"}
+        disabled={disabled}
         onClick={() => router.push(`/apply/${formId}`)}
       >
-        지원하기
+        {disabled ? "모집 완료" : "지원하기"}
       </SolidButton>
       <SolidButton
         icon="/icon/document-md.svg"

--- a/src/app/alba/[formId]/page.tsx
+++ b/src/app/alba/[formId]/page.tsx
@@ -1,4 +1,3 @@
-import SolidButton from "@/components/button/SolidButton";
 import Carousel from "@/components/Carousel/Carousel";
 import fetchData from "./fetchData";
 import Content from "./components/Content";
@@ -10,6 +9,7 @@ import DetailRequirements from "./components/DetailRequirements";
 import NoticeApplicant from "./components/NoticeApplicant";
 import NoticeIsClosed from "./components/NoticeIsClosed";
 import ScrapAndShareButton from "./components/ScrapAndShareButton";
+import ApllicantActionButtons from "./components/ApllicantActionButtons";
 import { AlbaformDetailData } from "@/types/alba";
 import { cookies } from "next/headers";
 
@@ -79,12 +79,7 @@ const AlbarformDetailPage = async ({ params }: PageProps) => {
           <StoreLocation location={data.location} />
         </section>
         <section className="flex w-full flex-col gap-[10px] pc:grid-in-box6">
-          <SolidButton icon="/icon/write-fill-md.svg" style="orange300">
-            지원하기
-          </SolidButton>
-          <SolidButton icon="/icon/document-md.svg" style="outOrange300">
-            내 지원 내역 보기
-          </SolidButton>
+          {role === "APPLICANT" && <ApllicantActionButtons formId={formId} />}
         </section>
       </div>
       <NoticeApplicant count={data.applyCount} />

--- a/src/app/alba/[formId]/page.tsx
+++ b/src/app/alba/[formId]/page.tsx
@@ -79,7 +79,12 @@ const AlbarformDetailPage = async ({ params }: PageProps) => {
           <StoreLocation location={data.location} />
         </section>
         <section className="flex w-full flex-col gap-[10px] pc:grid-in-box6">
-          {role === "APPLICANT" && <ApllicantActionButtons formId={formId} />}
+          {role === "APPLICANT" && (
+            <ApllicantActionButtons
+              formId={formId}
+              recruitmentEndDate={data.recruitmentEndDate}
+            />
+          )}
         </section>
       </div>
       <NoticeApplicant count={data.applyCount} />


### PR DESCRIPTION
## 🧩 이슈 번호 #152 

## 🔎 작업 내용
- 알바폼 상세페이지에서 지원자인 경우 ApllicantActionButtons 버튼을 렌더링하게 했습니다.
- ApllicantActionButtons는 formId를 받아 지원하기 버튼을 눌렀을 떄에는 지원하기 페이지로 이동하고, 내 지원 내역 보기 버튼을 눌렀을 떄에는 이에 해당하는 모달을 띄웁니다.

## 이미지 첨부
https://github.com/user-attachments/assets/8d866ebb-38e7-4c86-9dc7-0586bf093400

https://github.com/user-attachments/assets/7db13384-ed6e-4fa9-bab7-3693ea01d70d

### 모집 마감되었을 떄 

https://github.com/user-attachments/assets/fb6e95f5-b61e-42dc-855c-92f4a6580b42


## 🔧 앞으로의 과제

## 👩‍💻 공유 포인트 및 논의 사항
내 지원 내역 보기 모달에서 입력값을 다 넣고 제출했을 때 어떤 UI를 보여줘야 할지 의논이 필요해 보입니다.
