### PR TITLE
Fix: isPast 유틸함수 return문 수정

### DIFF
--- a/src/utils/isPast.ts
+++ b/src/utils/isPast.ts
@@ -3,7 +3,7 @@ const isPast = (isoDateString: string) => {
 
   const targetDate = new Date(isoDateString);
 
-  return targetDate > currentDate;
+  return targetDate < currentDate;
 };
 
 export default isPast;


### PR DESCRIPTION
## 🧩 이슈 번호 #206 

## 🔎 작업 내용
- 모집마감이 아닌데 모집마감 toast가 뜨는 버그 해결했습니다.
- 이유는 isPast 유틸함수의 return문 부등호가 반대로 되어있었습니다.
