### PR TITLE
Feat:마이페이지 레이아웃 구현

### DIFF
--- a/src/app/mypage/components/InfoEditContainer.tsx
+++ b/src/app/mypage/components/InfoEditContainer.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import SolidButton from "@/components/button/SolidButton";
+import MyInfoEditDropdown from "@/components/dropdown/MyInfoEditDropdown";
+import { useModal } from "@/hooks/useModal";
+
+const MyInfoEditContainer = () => {
+  const { openModal } = useModal();
+
+  return (
+    <div>
+      <div className="hidden pc:flex pc:gap-4">
+        <div className="h-[58px] w-[180px]">
+          <SolidButton
+            style="orange300"
+            onClick={() => openModal("ChangeMyInfoModal")}
+          >
+            내 정보 수정
+          </SolidButton>
+        </div>
+        <div className="h-[58px] w-[180px]">
+          <SolidButton
+            style="outOrange300"
+            onClick={() => openModal("ChangePasswordModal")}
+          >
+            비밀번호 변경
+          </SolidButton>
+        </div>
+      </div>
+      <div className="pc:hidden">
+        <MyInfoEditDropdown
+          onMyInfoEdit={() => openModal("ChangeMyInfoModal")}
+          onPasswordEdit={() => openModal("ChangePasswordModal")}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default MyInfoEditContainer;

--- a/src/app/mypage/components/MyComment.tsx
+++ b/src/app/mypage/components/MyComment.tsx
@@ -1,0 +1,5 @@
+const MyComment = async () => {
+  return <div></div>;
+};
+
+export default MyComment;

--- a/src/app/mypage/components/MyPost.tsx
+++ b/src/app/mypage/components/MyPost.tsx
@@ -1,0 +1,34 @@
+"use server";
+
+import Empty from "@/app/albatalk/components/Empty";
+import PostCard from "@/components/card/PostCard";
+import instance from "@/lib/instance";
+import { PostCardProps } from "@/types/post";
+
+const MyPost = async () => {
+  const response = await instance(
+    `${process.env.NEXT_PUBLIC_API_URL}/users/me/posts?limit=6`
+  );
+
+  if (response.status !== 200) {
+    return <div>오류 발생</div>;
+  }
+
+  const myPosts: PostCardProps[] = response.data.data;
+
+  return (
+    <div>
+      {myPosts.length > 0 ? (
+        <div className="grid grid-cols-1 gap-4 pc:grid-cols-3 pc:gap-x-[25px] pc:gap-y-[48px]">
+          {myPosts.map((myPost) => (
+            <PostCard key={myPost.id} info={myPost} />
+          ))}
+        </div>
+      ) : (
+        <Empty />
+      )}
+    </div>
+  );
+};
+
+export default MyPost;

--- a/src/app/mypage/components/MyScrap.tsx
+++ b/src/app/mypage/components/MyScrap.tsx
@@ -1,0 +1,5 @@
+const MyScrap = async () => {
+  return <div></div>;
+};
+
+export default MyScrap;

--- a/src/app/mypage/components/NavMenu.tsx
+++ b/src/app/mypage/components/NavMenu.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import MyPageButton from "./NavMenuButton";
+
+const NavMenu = () => {
+  return (
+    <div className="flex max-w-[327px] gap-[10px] rounded-[14px] bg-background-200 p-[6px] pc:w-[422px]">
+      <MyPageButton>내가 쓴 글</MyPageButton>
+      <MyPageButton>내가 쓴 댓글</MyPageButton>
+      <MyPageButton>스크랩</MyPageButton>
+    </div>
+  );
+};
+
+export default NavMenu;

--- a/src/app/mypage/components/NavMenuButton.tsx
+++ b/src/app/mypage/components/NavMenuButton.tsx
@@ -1,0 +1,9 @@
+const MyPageButton = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <button className="h-8 w-[98px] rounded-[8px] bg-gray-50 text-md font-semibold text-black-400 pc:w-[130px] pc:text-lg">
+      {children}
+    </button>
+  );
+};
+
+export default MyPageButton;

--- a/src/app/mypage/layout.tsx
+++ b/src/app/mypage/layout.tsx
@@ -1,0 +1,27 @@
+import NavMenu from "./components/NavMenu";
+import MyInfoEditContainer from "./components/InfoEditContainer";
+import OrderByDropdown from "@/components/dropdown/OrderByDropdown";
+
+const MyPageLayout = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <div className="mx-auto mt-4 box-content max-w-[327px] px-6 pb-[80px] pc:max-w-[1480px] tablet:max-w-[600px]">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold text-black-500 pc:text-3xl">
+          마이페이지
+        </h2>
+        <MyInfoEditContainer />
+      </div>
+      <div className="pc:mt-[46px] pc:flex pc:items-center pc:justify-between">
+        <div className="mt-6 flex justify-start pc:mt-0 tablet:mt-[30px]">
+          <NavMenu />
+        </div>
+        <div className="mt-4 flex justify-end pc:mt-0">
+          <OrderByDropdown />
+        </div>
+      </div>
+      <div className="mt-[30px] pc:mt-10 tablet:mt-[14px]">{children}</div>
+    </div>
+  );
+};
+
+export default MyPageLayout;

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,0 +1,27 @@
+import { Suspense } from "react";
+import MyComment from "./components/MyComment";
+import MyPost from "./components/MyPost";
+import MyScrap from "./components/MyScrap";
+
+const MyPage = async ({
+  searchParams,
+}: {
+  searchParams: Promise<{ orderBy: string }>;
+}) => {
+  const { orderBy } = await searchParams;
+  return (
+    <div>
+      <Suspense fallback={<div>로딩중...</div>}>
+        <MyPost />
+      </Suspense>
+      <Suspense fallback={<div>로딩중...</div>}>
+        <MyComment />
+      </Suspense>
+      <Suspense fallback={<div>로딩중...</div>}>
+        <MyScrap />
+      </Suspense>
+    </div>
+  );
+};
+
+export default MyPage;


### PR DESCRIPTION
## 🧩 이슈 번호 #234 

## 🔎 작업 내용
1. 마이페이지 레이아웃을 잡아 놓았습니다.
 - 타이틀
 - 개인 정보 수정 버튼 or 케밥
 - NavMenu ("내가 쓴 글", "내가 쓴 댓글", "스크랩")
 - orderByDropdown 
 - page content (메뉴에 선택 된 데이터가 랜더링 될 공간)

## 이미지 첨부
https://github.com/user-attachments/assets/7c54d0d4-f816-4e47-89cd-dfd84c6717dd


## 🔧 앞으로의 과제
1. "내가 쓴 글", "내가 쓴 댓글", "스크랩" 을 각각 데이터 패칭하여 랜더링 해야합니다
2. 각 리스트에 무한스크롤 적용
3. 사장님의 경우 스크랩을 메뉴에서 제거

