### PR TITLE
Feat: SNS 간편로그인 UI만 구현

### DIFF
--- a/src/app/(auth)/components/EazyLogin.tsx
+++ b/src/app/(auth)/components/EazyLogin.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import Image from "next/image";
+import { usePathname } from "next/navigation";
+
+const EazyLogin = () => {
+  const pathname = usePathname();
+  const isSigninPage = pathname.includes("/signin");
+  const loginOrSignup = isSigninPage ? "로그인" : "회원가입";
+
+  return (
+    <section className="flex h-[96px] w-full flex-col gap-6 text-md">
+      <div className="flex items-center gap-[13px] text-gray-300">
+        <div className="h-0 w-full border border-gray-100" />
+        <span className="w-[500px]">SNS 계정으로 {loginOrSignup} 하기</span>
+        <div className="h-0 w-full border border-gray-100" />
+      </div>
+
+      <div className="mx-auto flex h-[48px] w-[112px] gap-4">
+        <button>
+          <Image
+            src={"/logo/logo-google.svg"}
+            width={48}
+            height={48}
+            alt="google logo"
+          />
+        </button>
+        <button>
+          <Image
+            src={"/logo/logo-kakao.svg"}
+            width={48}
+            height={48}
+            alt="kakao logo"
+          />
+        </button>
+      </div>
+    </section>
+  );
+};
+
+export default EazyLogin;

--- a/src/app/(auth)/signin/[userType]/page.tsx
+++ b/src/app/(auth)/signin/[userType]/page.tsx
@@ -1,5 +1,6 @@
 import SigninTitle from "../components/SigninTitle";
 import SigninContents from "../components/SigninContents";
+import EazyLogin from "../../components/EazyLogin";
 import { Metadata } from "next";
 
 interface SigninPageProps {
@@ -17,6 +18,7 @@ const SigninPage = async ({ params }: SigninPageProps) => {
     <>
       <SigninTitle userType={userType} />
       <SigninContents />
+      <EazyLogin />
     </>
   );
 };

--- a/src/app/(auth)/signup/[userType]/page.tsx
+++ b/src/app/(auth)/signup/[userType]/page.tsx
@@ -1,5 +1,6 @@
 import SignupTitle from "../components/SignupTitle";
 import SignupContents from "../components/SignupContents";
+import EazyLogin from "../../components/EazyLogin";
 import { Metadata } from "next";
 
 interface SignupPageProps {
@@ -19,6 +20,7 @@ const SignupPage = async ({ params, searchParams }: SignupPageProps) => {
     <>
       <SignupTitle userType={userType} stepOneDone={stepOneDone} />
       <SignupContents userType={userType} stepOneDone={stepOneDone} />
+      <EazyLogin />
     </>
   );
 };


### PR DESCRIPTION
## 🧩 이슈 번호 #260

## 🔎 작업 내용
- 로그인 및 회원가입 페이지에서 EazyLogin 컴포넌트가 보이도록 했습니다.
- 기능은 작업중인데 오래 걸릴 것 같아 ui만 push한  상황입니다.

## 이미지 첨부
https://github.com/user-attachments/assets/c51d325f-3722-472f-85f1-45ffb0c5b965

## 🔧 앞으로의 과제
- 간편 로그인/회원가입 기능 구현

## 👩‍💻 공유 포인트 및 논의 사항
- 일단 작업중이긴 한데 Oauth를 처음 다뤄봐서 개념을 이해하고 적용하는데 시간이 조금 걸리는 것 같습니다(17일 자정 이후에나 구현 가능할 것으로 예상)
- 리팩토링 기간에 다른 분들 리팩토링 하실 때 저는 이거 매달려야 하나 흠.. 고민입니다