### PR TITLE
Feat: "지원상태 수정" 모달 기능 구현

### DIFF
--- a/src/app/test/page.tsx
+++ b/src/app/test/page.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useModal } from "@/hooks/useModal";
+
+const TestPage = () => {
+  const { openModal } = useModal();
+  return (
+    <div>
+      <div>
+        <button onClick={() => openModal("SelectProgressModal")}>
+          진행 상태 수정 모달
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default TestPage;

--- a/src/atoms/modalAtom.tsx
+++ b/src/atoms/modalAtom.tsx
@@ -4,3 +4,5 @@ import { atom } from "jotai";
 import { ModalType } from "@/types/modal";
 
 export const modalAtom = atom<ModalType | null>(null);
+
+export const applicationIdAtom = atom<number | null>(null);

--- a/src/atoms/modalAtomStore.ts
+++ b/src/atoms/modalAtomStore.ts
@@ -3,6 +3,8 @@
 import { atom } from "jotai";
 import { ModalType } from "@/types/modal";
 
+//모달타입
 export const modalAtom = atom<ModalType | null>(null);
 
+//지원서 아이디
 export const applicationIdAtom = atom<number | null>(null);

--- a/src/components/modal/modalActions/selectProgressAction.ts
+++ b/src/components/modal/modalActions/selectProgressAction.ts
@@ -1,0 +1,31 @@
+"use server";
+
+import instance from "@/lib/instance";
+import { ProgressValue } from "../modalContent/SelectProgressModal";
+
+export const selectProgressAction = async (
+  status: ProgressValue,
+  applicationId: number | null
+) => {
+  const response = await instance(
+    `${process.env.NEXT_PUBLIC_API_URL}/applications/${applicationId}`,
+    {
+      method: "PATCH",
+      body: JSON.stringify(status),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    }
+  );
+
+  if (response.status !== 200) {
+    return {
+      status: response.status,
+      message: response.error,
+    };
+  }
+
+  return {
+    status: response.status,
+  };
+};

--- a/src/components/modal/modalContent/DeleteAlbaformModal.tsx
+++ b/src/components/modal/modalContent/DeleteAlbaformModal.tsx
@@ -13,7 +13,7 @@ const DeleteAlbaformModal = () => {
   const { addToast } = useToast();
   const router = useRouter();
   const params = useParams();
-  const id = params.id as string;
+  const id = params.formId as string;
 
   const handleDeleteAlbaform = async () => {
     if (!id) return;

--- a/src/components/modal/modalContent/SelectProgressModal.tsx
+++ b/src/components/modal/modalContent/SelectProgressModal.tsx
@@ -5,25 +5,50 @@ import SolidButton from "@/components/button/SolidButton";
 import useViewPort from "@/hooks/useViewport";
 import { useState } from "react";
 import { useModal } from "@/hooks/useModal";
+import { useToast } from "@/hooks/useToast";
+import { selectProgressAction } from "../modalActions/selectProgressAction";
+import { useAtomValue } from "jotai";
+import { applicationIdAtom } from "@/atoms/modalAtom";
 
-const progressList = [
-  { name: "거절" },
-  { name: "면접 대기" },
-  { name: "면접 완료" },
-  { name: "채용 완료" },
+export type ProgressValue =
+  | "REJECTED"
+  | "INTERVIEW_PENDING"
+  | "INTERVIEW_COMPLETED"
+  | "HIRED";
+
+const progressList: { name: string; value: ProgressValue }[] = [
+  { name: "거절", value: "REJECTED" },
+  { name: "면접 대기", value: "INTERVIEW_PENDING" },
+  { name: "면접 완료", value: "INTERVIEW_COMPLETED" },
+  { name: "채용 완료", value: "HIRED" },
 ];
 
 const SelectProgressModal = () => {
   const { closeModal } = useModal();
+  const { addToast } = useToast();
   const viewPort = useViewPort();
-  const [selected, setSelected] = useState("면접 대기");
+  const [selected, setSelected] = useState<ProgressValue>("INTERVIEW_PENDING");
+  const applicationId = useAtomValue(applicationIdAtom);
 
-  const handleChange = (value: string) => {
+  const handleChange = (value: ProgressValue) => {
     setSelected(value);
   };
 
-  const handleSubmit = () => {
-    // 지원 상태 수정 api 요청
+  const handleSubmit = async () => {
+    try {
+      const response = await selectProgressAction(selected, applicationId);
+
+      if (response.status === 200) {
+        addToast("지원상태 수정이 완료되었습니다.", "success");
+        closeModal();
+      } else {
+        console.error(response.message, response.status);
+        addToast(response.message as string, "warning");
+      }
+    } catch (error) {
+      console.error("지원상태 수정 에러 발생", error);
+      addToast("지원상태 수정 중 오류가 발생했습니다.", "warning");
+    }
   };
 
   return (
@@ -36,15 +61,15 @@ const SelectProgressModal = () => {
           {progressList.map((progress) => (
             <li key={progress.name}>
               <label
-                className={`bg-orang-100 flex items-center justify-between rounded-[8px] border border-line-100 p-[14px] text-md font-medium pc:text-2lg ${selected === progress.name ? "border-orange-300 bg-orange-500" : ""}`}
+                className={`bg-orang-100 flex items-center justify-between rounded-[8px] border border-line-100 p-[14px] text-md font-medium pc:text-2lg ${selected === progress.value ? "border-orange-300 bg-orange-300 text-gray-50" : ""}`}
               >
                 {progress.name}
                 <input
                   type="radio"
                   name="progress"
-                  value={progress.name}
-                  checked={selected === progress.name}
-                  onChange={() => handleChange(progress.name)}
+                  value={progress.value}
+                  checked={selected === progress.value}
+                  onChange={() => handleChange(progress.value)}
                   className="size-5 appearance-none rounded-full border-[5px] border-gray-50 ring-1 ring-gray-300 checked:bg-orange-300 checked:ring-orange-300"
                 />
               </label>
@@ -70,10 +95,7 @@ const SelectProgressModal = () => {
               size={viewPort === "pc" ? "large" : "small"}
               style="orange300"
               type="button"
-              onClick={() => {
-                closeModal();
-                handleSubmit;
-              }}
+              onClick={handleSubmit}
             >
               선택하기
             </SolidButton>

--- a/src/components/modal/modalContent/SelectProgressModal.tsx
+++ b/src/components/modal/modalContent/SelectProgressModal.tsx
@@ -8,7 +8,7 @@ import { useModal } from "@/hooks/useModal";
 import { useToast } from "@/hooks/useToast";
 import { selectProgressAction } from "../modalActions/selectProgressAction";
 import { useAtomValue } from "jotai";
-import { applicationIdAtom } from "@/atoms/modalAtom";
+import { applicationIdAtom } from "@/atoms/modalAtomStore";
 
 export type ProgressValue =
   | "REJECTED"

--- a/src/components/modal/modalManager/ModalManager.tsx
+++ b/src/components/modal/modalManager/ModalManager.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useAtomValue } from "jotai";
-import { modalAtom } from "@/atoms/modalAtom";
+import { modalAtom } from "@/atoms/modalAtomStore";
 import CloseAlbaformModal from "../modalContent/ClosedAlbaformModal";
 import DeleteAlbaformModal from "../modalContent/DeleteAlbaformModal";
 import PatchAlbaformModal from "../modalContent/PatchAlbaformModal";

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { modalAtom } from "@/atoms/modalAtom";
+import { modalAtom } from "@/atoms/modalAtomStore";
 import { ModalType } from "@/types/modal";
 import { useSetAtom } from "jotai";
 


### PR DESCRIPTION
## 🧩 이슈 번호 #248 

## 🔎 작업 내용
1. "지원상태" 선택 후 데이터 패칭 요청 기능 추가
2. 지원서 id를 받기 위해 전역 상태관리 추가하였습니다.
` export const applicationIdAtom = atom<number | null>(null);`

## 이미지 첨부
![image](https://github.com/user-attachments/assets/4c15890c-57b4-4d7b-a431-935c7ad1e649)



## 👩‍💻 공유 포인트 및 논의 사항
모달을 사용할 때 지원서 id값을 받아야하는데 전역으로 설정한 applicationIdAtom에 저장해줘야 합니다.
