### PR TITLE
Fix: 알바폼상세페이지 디버깅 작업(80%완료)

### DIFF
--- a/src/app/alba/[formId]/components/Content.tsx
+++ b/src/app/alba/[formId]/components/Content.tsx
@@ -1,6 +1,8 @@
 const Content = ({ description }: { description: string }) => {
+  console.log(description);
+
   return (
-    <p className="px-6 py-4 text-md text-black-400 pc:text-2xl">
+    <p className="whitespace-pre-line px-6 py-4 text-md text-black-400 pc:text-2xl">
       {description}
     </p>
   );

--- a/src/app/alba/[formId]/components/DetailRequirements.tsx
+++ b/src/app/alba/[formId]/components/DetailRequirements.tsx
@@ -2,7 +2,7 @@ interface DetailRequirementsProps {
   age: string | "연령무관";
   education: string | "학력무관";
   gender: string | "성별무관";
-  numberOfPositions: number | "00명(인원미정)";
+  numberOfPositions: number;
   preferred: string;
 }
 
@@ -11,7 +11,10 @@ const DetailRequirements = ({ info }: { info: DetailRequirementsProps }) => {
     {
       id: 0,
       title: "모집인원",
-      content: info.numberOfPositions,
+      content:
+        info.numberOfPositions === 0 || !info.numberOfPositions
+          ? "00명(인원미정)"
+          : `${info.numberOfPositions}명`,
     },
     {
       id: 1,

--- a/src/app/alba/[formId]/components/SimpleRequirements.tsx
+++ b/src/app/alba/[formId]/components/SimpleRequirements.tsx
@@ -16,14 +16,14 @@ const SimpleRequirements = ({ info }: { info: SimpleRequirementsProps }) => {
     info.workEndDate
   );
 
-  const workdays = info.workDays.join(",");
+  const workdays = info.workDays.join(", ");
 
   const infoList = [
     {
       id: 0,
       href: "/icon/database-md.svg",
       title: "시급",
-      content: info.hourlyWage,
+      content: `${info.hourlyWage}원`,
     },
     {
       id: 1,

--- a/src/utils/isPast.ts
+++ b/src/utils/isPast.ts
@@ -1,5 +1,5 @@
 const isPast = (isoDateString: string) => {
-  const currentDate = new Date(); // 현재 시각 반환
+  const currentDate = new Date();
 
   const targetDate = new Date(isoDateString);
 


### PR DESCRIPTION
## 🧩 이슈 번호 #231 

## 🔎 작업 내용
- 1차 배포 때 알바폼 상세페이지에서 발견한 버그들 고치는 작업입니다. 리스트는 아래와 같습니다

### 🚧 수정한 버그리스트
- [x] 0명 지원했을 때 토스트 팝업 안되게 하기
- [x] 마감일이 오늘인데도 불구하고 toast가 뜨는 문제
- [x] 모집인원이 0명일 때 "00명(인원미정)"이라고 띄우기
- [x] 시급에 "원" 붙히기
- [x] 요일 , 이후에 띄어쓰기
- [x] ActionButton 3개이상 생길 경우 모집조건이 겹치는 부분
- [x] "지원 현황 조회", 버튼이 사장님 본인 form일 때에만 렌더링 되게 하기
- [x] "모집중" "모집완료" ui가 싱크가 안 맞음.
- [x] description 부분, 줄바꿈 안되는 문제 -> 알바폼 등록하기에서 줄바꿈해서 서버에 저장하고, 서버에 저장된 데이터에서 줄바꿈을 어떻게 인식하고 있는지부터 테스트해야 합니다.

## 🔧 앞으로의 과제
- [ ] 캐러셀 기본 이미지 없음-> 이미지 업로드 input에서 해결하면 전반적으로 다 해결되는 문제인 것 같습니다.
- [ ] 태블릿일 경우, 좌우 여백이 너무 넓음 -> 이거는 tablet 이미지일 때 컴포넌트 전체 UI를 비교적 넓게 바꾸어야 하는 상황이어서 피그마에서 준 초안대로 가지 않고 아예 바꾸어야 하는 상황입니다.