### PR TITLE
Fix: instance 버그 수정 및 미들웨어 최신화

### DIFF
--- a/src/lib/instance.ts
+++ b/src/lib/instance.ts
@@ -1,24 +1,59 @@
 "use server";
 
-import { cookies, headers } from "next/headers";
+import { cookies } from "next/headers";
+import { deleteCookie } from "./cookie";
 
 // 토큰이 필요한 요청을 할 때 fetch 대신 instance를 사용합니다.
 const instance = async (url: string, options: RequestInit = {}) => {
   const cookieStore = await cookies();
   const accessToken = cookieStore.get("accessToken")?.value;
-  const instanceHeader = new Headers(options.headers || {});
-  instanceHeader.set("x-instance-request", "true");
-  console.log(instanceHeader);
+
   if (accessToken) {
-    instanceHeader.set("Authorization", `Bearer ${accessToken}`);
+    options.headers = {
+      ...options.headers,
+      Authorization: `Bearer ${accessToken}`,
+    };
   }
 
-  const headerOptions = {
-    ...options,
-    headers: instanceHeader,
-  };
+  let response = await fetch(url, { ...options });
 
-  let response = await fetch(url, headerOptions);
+  if (response.status === 401) {
+    const refreshToken = cookieStore.get("refreshToken")?.value;
+
+    if (refreshToken) {
+      const refreshResponse = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/auth/refresh`,
+        {
+          method: "POST",
+          body: JSON.stringify({ refreshToken }),
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+
+      if (refreshResponse.ok) {
+        const tokenData = await refreshResponse.json();
+        const { accessToken: newAccessToken } = tokenData;
+
+        cookieStore.set("accessToken", newAccessToken);
+
+        options.headers = {
+          ...options.headers,
+          Authorization: `Bearer ${newAccessToken}`,
+        };
+
+        response = await fetch(url, { ...options });
+      } else {
+        console.error("토큰갱신 실패");
+        await deleteCookie(true);
+        return {
+          status: 401,
+          error: "장시간 미활동으로 인해 로그인이 해제되었습니다.",
+        };
+      }
+    }
+  }
 
   if (response.status === 204) {
     return {
@@ -35,9 +70,11 @@ const instance = async (url: string, options: RequestInit = {}) => {
     };
   }
 
+  const responseData = await response.json();
+
   return {
     status: response.status,
-    data: await response.json(),
+    ...responseData,
   }; // 각 요청의 응답을 json으로 반환합니다.
 };
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,26 +1,120 @@
 import { NextRequest, NextResponse } from "next/server";
 
-export const middleware = (request: NextRequest) => {
+export const middleware = async (request: NextRequest) => {
   const url = new URL(request.url);
   const path = url.pathname;
   const role = request.cookies.get("role");
-  const referrer = request.headers.get("referrer");
-  const ownerPath = ["/owner", "/addform"];
+  const referer = request.headers.get("referer");
+  const ownerPath = ["/owner", "/addform", "/addform/", "/applications/"];
+  const applicantPath = ["/applicant", "/apply/", "/myapply/"];
+  const accessToken = request.cookies.get("accessToken");
+  const instanceRequest = request.headers.get("x-instance-request") === "true";
+  console.log(instanceRequest);
 
-  if (role && role.value === "APPLICANT" && ownerPath.includes(path)) {
-    // 사장님용 페이지라고 알려주는 모달 오픈 또는 경고 후 이전페이지로 리다이렉트
-    return NextResponse.redirect(new URL(referrer || "/", request.url));
+  // instance로 요청이 들어왔을 때의 토큰 갱신 및 재요청
+  if (instanceRequest) {
+    console.log("instanceRequest");
+    if (!accessToken) {
+      return NextResponse.json(
+        { error: "로그인이 필요한 서버스입니다." },
+        { status: 401 }
+      );
+    }
+
+    try {
+      const response = await fetch(request);
+      const cookieList = ["accessToken", "refreshToken", "role", "id"];
+
+      if (response.status === 401) {
+        const refreshToken = request.cookies.get("refreshToken")?.value;
+
+        if (!refreshToken) {
+          const response = NextResponse.json(
+            { error: "장시간 미활동으로 인해 로그인이 해제되었습니다." },
+            { status: 401 }
+          );
+
+          cookieList.forEach((cookie) => {
+            response.cookies.delete(cookie);
+          });
+
+          return response;
+        }
+
+        const refreshResponse = await fetch(
+          `${process.env.NEXT_PUBLIC_API_URL}/auth/refresh`,
+          {
+            method: "POST",
+            body: JSON.stringify({ refreshToken }),
+            headers: {
+              "Content-Type": "application/json",
+            },
+          }
+        );
+        console.log(refreshResponse);
+        if (refreshResponse.ok) {
+          const tokenData = await refreshResponse.json();
+          const { accessToken: newAccessToken } = tokenData;
+
+          const response = NextResponse.next();
+          response.cookies.set({
+            name: "accessToken",
+            value: newAccessToken,
+          });
+
+          const newRequest = new Request(request.url, {
+            method: request.method,
+            headers: new Headers(request.headers),
+            body: request.body,
+          });
+          newRequest.headers.set("Authorization", `Bearer ${newAccessToken}`);
+
+          const retryResponse = await fetch(newRequest);
+          const responseResult = NextResponse.json(await retryResponse.json(), {
+            status: retryResponse.status,
+          });
+
+          return responseResult;
+        } else {
+          const response = NextResponse.redirect(
+            new URL("/signin", request.url)
+          );
+
+          cookieList.forEach((cookie) => {
+            response.cookies.delete(cookie);
+          });
+
+          return response;
+        }
+      }
+    } catch (error) {
+      return NextResponse.json(
+        { error: "오류가 발생하여 요청이 실패했습니다." },
+        { status: 500 }
+      );
+    }
   }
 
-  if (role && role.value === "OWNER" && path.startsWith("/applicant")) {
-    // 지원자용 페이지라고 알려주는 모달 오픈 또는 경고 후 이전페이지로 리다이렉트
-    return NextResponse.redirect(new URL(referrer || "/", request.url));
+  // 사장님용 페이지
+  if (role && role.value === "APPLICANT" && ownerPath.includes(path)) {
+    const prevUrl = referer || url.origin;
+    const errorUrl = new URL(prevUrl);
+    errorUrl.searchParams.set("error", "matchErrror");
+
+    return NextResponse.redirect(errorUrl);
+  }
+
+  // 지원자용 페이지
+  if (role && role.value === "OWNER" && applicantPath.includes(path)) {
+    const prevUrl = referer || url.origin;
+    const errorUrl = new URL(prevUrl);
+    errorUrl.searchParams.set("error", "matchErrror");
+
+    return NextResponse.redirect(errorUrl);
   }
 
   // 로그인되어 있으면 로그인페이지로 못가도록 막음
   if (path.startsWith("/signin")) {
-    const accessToken = request.cookies.get("accessToken");
-
     if (accessToken) {
       return NextResponse.redirect(new URL("/", request.url));
     }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,109 +8,31 @@ export const middleware = async (request: NextRequest) => {
   const ownerPath = ["/owner", "/addform", "/addform/", "/applications/"];
   const applicantPath = ["/applicant", "/apply/", "/myapply/"];
   const accessToken = request.cookies.get("accessToken");
-  const instanceRequest = request.headers.get("x-instance-request") === "true";
-  console.log(instanceRequest);
-
-  // instance로 요청이 들어왔을 때의 토큰 갱신 및 재요청
-  if (instanceRequest) {
-    console.log("instanceRequest");
-    if (!accessToken) {
-      return NextResponse.json(
-        { error: "로그인이 필요한 서버스입니다." },
-        { status: 401 }
-      );
-    }
-
-    try {
-      const response = await fetch(request);
-      const cookieList = ["accessToken", "refreshToken", "role", "id"];
-
-      if (response.status === 401) {
-        const refreshToken = request.cookies.get("refreshToken")?.value;
-
-        if (!refreshToken) {
-          const response = NextResponse.json(
-            { error: "장시간 미활동으로 인해 로그인이 해제되었습니다." },
-            { status: 401 }
-          );
-
-          cookieList.forEach((cookie) => {
-            response.cookies.delete(cookie);
-          });
-
-          return response;
-        }
-
-        const refreshResponse = await fetch(
-          `${process.env.NEXT_PUBLIC_API_URL}/auth/refresh`,
-          {
-            method: "POST",
-            body: JSON.stringify({ refreshToken }),
-            headers: {
-              "Content-Type": "application/json",
-            },
-          }
-        );
-        console.log(refreshResponse);
-        if (refreshResponse.ok) {
-          const tokenData = await refreshResponse.json();
-          const { accessToken: newAccessToken } = tokenData;
-
-          const response = NextResponse.next();
-          response.cookies.set({
-            name: "accessToken",
-            value: newAccessToken,
-          });
-
-          const newRequest = new Request(request.url, {
-            method: request.method,
-            headers: new Headers(request.headers),
-            body: request.body,
-          });
-          newRequest.headers.set("Authorization", `Bearer ${newAccessToken}`);
-
-          const retryResponse = await fetch(newRequest);
-          const responseResult = NextResponse.json(await retryResponse.json(), {
-            status: retryResponse.status,
-          });
-
-          return responseResult;
-        } else {
-          const response = NextResponse.redirect(
-            new URL("/signin", request.url)
-          );
-
-          cookieList.forEach((cookie) => {
-            response.cookies.delete(cookie);
-          });
-
-          return response;
-        }
-      }
-    } catch (error) {
-      return NextResponse.json(
-        { error: "오류가 발생하여 요청이 실패했습니다." },
-        { status: 500 }
-      );
-    }
-  }
 
   // 사장님용 페이지
   if (role && role.value === "APPLICANT" && ownerPath.includes(path)) {
-    const prevUrl = referer || url.origin;
-    const errorUrl = new URL(prevUrl);
-    errorUrl.searchParams.set("error", "matchErrror");
+    // const prevUrl = referer || url.origin;
+    // const errorUrl = new URL(prevUrl);
+    // errorUrl.searchParams.set("error", "matchErrror");
 
-    return NextResponse.redirect(errorUrl);
+    if (referer) {
+      return NextResponse.redirect(referer);
+    } else {
+      return NextResponse.redirect(url.origin);
+    }
   }
 
   // 지원자용 페이지
   if (role && role.value === "OWNER" && applicantPath.includes(path)) {
-    const prevUrl = referer || url.origin;
-    const errorUrl = new URL(prevUrl);
-    errorUrl.searchParams.set("error", "matchErrror");
+    // const prevUrl = referer || url.origin;
+    // const errorUrl = new URL(prevUrl);
+    // errorUrl.searchParams.set("error", "matchErrror");
 
-    return NextResponse.redirect(errorUrl);
+    if (referer) {
+      return NextResponse.redirect(referer);
+    } else {
+      return NextResponse.redirect(url.origin);
+    }
   }
 
   // 로그인되어 있으면 로그인페이지로 못가도록 막음

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -35,6 +35,13 @@ export const middleware = async (request: NextRequest) => {
     }
   }
 
+  // 비회원이 전용페이지 접근하는 것을 차단
+  if (!role && !accessToken) {
+    if (ownerPath.includes(path) || applicantPath.includes(path)) {
+      return NextResponse.redirect(new URL("/signin/applicant", request.url));
+    }
+  }
+
   // 로그인되어 있으면 로그인페이지로 못가도록 막음
   if (path.startsWith("/signin")) {
     if (accessToken) {


### PR DESCRIPTION
## 🧩 이슈 번호 #250 #254

## 🔎 작업 내용
<!-- - 기능에서 어떤 부분이 구현되었는지 설명해주세요. -->
- 기존에 instance를 통해 토큰이 포함된 요청을 했을 때 401 에러가 반환되면 리프레시토큰 요청 및 재요청 로직이 작동하지 않았습니다.
- 이 문제는 instance 함수에서 401에러 객체를 return하여 이후 로직이 실행되지 않았기 때문입니다. 즉, 이후 요청이 가로채지고 끝나버려서 발생한 문제였습니다.
- 그래서 instance 상단에서 미리 액세스토큰이 있나없나로 401에러를 반환하지 않고, 실제 요청을 한 이후에 관련 처리를 하도록 변경했습니다.
- 미들웨어도 전용페이지 접근을 차단하는 로직을 업데이트했습니다.
- 반환되는 데이터를 받으면 response.data.data 식으로 되는 것을 막기위해 해당 부분을 수정했습니다.

## 이미지 첨부
<!-- preview 이미지 혹 동영상을 첨부해주세요. -->
https://github.com/user-attachments/assets/184514a5-ada5-4088-951e-f7465fce46f2

## 🔧 앞으로의 과제

<!-- - 이번 이슈에서 앞으로 남은 할 일을 적어주세요. -->
- 이번 이슈에서는 없음

## 👩‍💻 공유 포인트 및 논의 사항

<!-- 공유하거나 논의할 사항을 작성해주세요. -->
- 반환되는 데이터 객체를 수정했기 때문에 일부 컴포넌트에서 response.data 형식으로 수정이 필요할 수 있습니다. merge 되면 작업하신 부분의 요청이 잘 되는지 확인이 필요할 것 같습니다.
