### PR TITLE
Chore: 알바폼 만들기 작성중 태그 활성화 여부 로직 수정

### DIFF
--- a/src/app/addform/components/StepButton.tsx
+++ b/src/app/addform/components/StepButton.tsx
@@ -1,24 +1,30 @@
 "use client";
 
 import { cls } from "@/utils/dynamicTailwinds";
-import { useEffect } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import WritingTag from "./WritingTag";
-import { addFormStepAtom } from "@/atoms/addFormAtomStore";
-import { useAtom } from "jotai";
+import { addFormStepAtom, stepActiveAtomFamily } from "@/atoms/addFormAtomStore";
+import { useAtom, useAtomValue } from "jotai";
 import { useSearchParamsCustom } from "@/hooks/useSearchParamsCustom";
 
 const StepButton = () => {
   const [currentStep, setCurrentStep] = useAtom(addFormStepAtom);
+  const stepOneActive = useAtomValue(stepActiveAtomFamily("stepOne"));
+  const stepTwoActive = useAtomValue(stepActiveAtomFamily("stepTwo"));
+  const stepThreeActive = useAtomValue(stepActiveAtomFamily("stepThree"));
   const { updateURL } = useSearchParamsCustom({
     key: "step",
     value: currentStep.value,
   });
 
-  const stepArr = [
-    { title: "모집 내용", step: 1, value: "stepOne" },
-    { title: "모집 조건", step: 2, value: "stepTwo" },
-    { title: "근무 조건", step: 3, value: "stepThree" },
-  ];
+  const stepArr = useMemo(
+    () => [
+      { title: "모집 내용", step: 1, value: "stepOne", active: stepOneActive },
+      { title: "모집 조건", step: 2, value: "stepTwo", active: stepTwoActive },
+      { title: "근무 조건", step: 3, value: "stepThree", active: stepThreeActive },
+    ],
+    [stepOneActive, stepTwoActive, stepThreeActive]
+  );
 
   const handleClickStep = (value: string) => {
     setCurrentStep({
@@ -62,7 +68,9 @@ const StepButton = () => {
           {item.title}
         </h2>
       </div>
-      <WritingTag currentStep={currentStep.value} value={item.value} />
+      {item.active && (
+        <WritingTag currentStep={currentStep.value} value={item.value} />
+      )}
     </button>
   ));
 };

--- a/src/app/addform/components/StepButton.tsx
+++ b/src/app/addform/components/StepButton.tsx
@@ -1,9 +1,12 @@
 "use client";
 
 import { cls } from "@/utils/dynamicTailwinds";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo } from "react";
 import WritingTag from "./WritingTag";
-import { addFormStepAtom, stepActiveAtomFamily } from "@/atoms/addFormAtomStore";
+import {
+  addFormStepAtom,
+  stepActiveAtomFamily,
+} from "@/atoms/addFormAtomStore";
 import { useAtom, useAtomValue } from "jotai";
 import { useSearchParamsCustom } from "@/hooks/useSearchParamsCustom";
 
@@ -21,7 +24,12 @@ const StepButton = () => {
     () => [
       { title: "모집 내용", step: 1, value: "stepOne", active: stepOneActive },
       { title: "모집 조건", step: 2, value: "stepTwo", active: stepTwoActive },
-      { title: "근무 조건", step: 3, value: "stepThree", active: stepThreeActive },
+      {
+        title: "근무 조건",
+        step: 3,
+        value: "stepThree",
+        active: stepThreeActive,
+      },
     ],
     [stepOneActive, stepTwoActive, stepThreeActive]
   );

--- a/src/app/addform/components/StepContainer.tsx
+++ b/src/app/addform/components/StepContainer.tsx
@@ -10,6 +10,7 @@ import {
   addFormSubmitDisabledAtom,
   addFormIsSubmittingAtom,
   addFromSubmitTriggerAtom,
+  stepActiveAtomFamily,
 } from "@/atoms/addFormAtomStore";
 import { useAtom, useSetAtom } from "jotai";
 import { handleDateRangeFormat } from "@/utils/formatAddFormDate";
@@ -43,6 +44,9 @@ const StepContainer = ({ albaForm, formId }: StepContainerProps) => {
   const router = useRouter();
   const isEdit = albaForm && !("status" in albaForm);
   const isInitialized = useRef(false);
+  const setStepOneActive = useSetAtom(stepActiveAtomFamily("stepOne"));
+  const setStepTwoActive = useSetAtom(stepActiveAtomFamily("stepTwo"));
+  const setStepThreeActive = useSetAtom(stepActiveAtomFamily("stepThree"));
 
   useEffect(() => {
     if (albaForm && !isInitialized.current) {
@@ -69,6 +73,10 @@ const StepContainer = ({ albaForm, formId }: StepContainerProps) => {
           recruitmentStartDate: recruitmentDates[0],
           recruitmentEndDate: recruitmentDates[1],
         });
+
+        setStepOneActive(true);
+        setStepTwoActive(true);
+        setStepThreeActive(true);
 
         if (albaForm.imageUrls && albaForm.imageUrls.length > 0) {
           const convertToFile = async () => {

--- a/src/app/addform/components/StepOneContents.tsx
+++ b/src/app/addform/components/StepOneContents.tsx
@@ -1,5 +1,6 @@
 import {
   currentImageListAtom,
+  stepActiveAtomFamily,
   temporaryDataByStepAtom,
 } from "@/atoms/addFormAtomStore";
 import ErrorText from "@/components/errorText/ErrorText";
@@ -28,6 +29,7 @@ const StepOneContents = () => {
   } = useFormContext<z.infer<typeof addFormSchema>>();
   const [currentImageList, setCurrentImageList] = useAtom(currentImageListAtom);
   const setTemporaryDataByStep = useSetAtom(temporaryDataByStepAtom);
+  const setStepOneActive = useSetAtom(stepActiveAtomFamily("stepOne"));
   const [temporaryDateRange, setTemporaryDateRange] = useState<
     [string, string]
   >(() => {
@@ -44,6 +46,20 @@ const StepOneContents = () => {
     "recruitmentEndDate",
   ] as const;
   const [loading, setLoading] = useState(true);
+
+  // 1단계 '작성중' 태그 여부
+  useEffect(() => {
+    const subscription = watch((value, { name }) => {
+      if (name && fields.includes(name as (typeof fields)[number])) {
+        const currentValue = value[name as keyof typeof value];
+        if (currentValue && String(currentValue).trim() !== "") {
+          setStepOneActive(true);
+        }
+      }
+    });
+
+    return () => subscription.unsubscribe();
+  }, [watch, fields]);
 
   const stepOneData = useMemo(() => {
     return fields.reduce(

--- a/src/app/addform/components/StepOneContents.tsx
+++ b/src/app/addform/components/StepOneContents.tsx
@@ -59,7 +59,7 @@ const StepOneContents = () => {
     });
 
     return () => subscription.unsubscribe();
-  }, [watch, fields]);
+  }, [watch, fields, setStepOneActive]);
 
   const stepOneData = useMemo(() => {
     return fields.reduce(

--- a/src/app/addform/components/StepThreeContents.tsx
+++ b/src/app/addform/components/StepThreeContents.tsx
@@ -57,7 +57,7 @@ const StepThreeContents = () => {
     });
 
     return () => subscription.unsubscribe();
-  }, [watch, fields]);
+  }, [watch, fields, setStepActive]);
 
   // 임시 데이터 atom 업데이트
   useEffect(() => {

--- a/src/app/addform/components/StepThreeContents.tsx
+++ b/src/app/addform/components/StepThreeContents.tsx
@@ -1,7 +1,10 @@
 import { useFormContext } from "react-hook-form";
 import { addFormSchema } from "@/schema/addForm/addFormSchema";
 import { z } from "zod";
-import { temporaryDataByStepAtom } from "@/atoms/addFormAtomStore";
+import {
+  stepActiveAtomFamily,
+  temporaryDataByStepAtom,
+} from "@/atoms/addFormAtomStore";
 import { useSetAtom } from "jotai";
 import Location from "./stepThree/Location";
 import RecruitmentDate from "./stepThree/RecruitmentDate";
@@ -16,6 +19,7 @@ import LoadingSkeleton from "./LoadingSkeleton";
 const StepThreeContents = () => {
   const { watch, setValue } = useFormContext<z.infer<typeof addFormSchema>>();
   const setTemporaryDataByStep = useSetAtom(temporaryDataByStepAtom);
+  const setStepActive = useSetAtom(stepActiveAtomFamily("stepThree"));
   const [loading, setLoading] = useState(true);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -39,6 +43,20 @@ const StepThreeContents = () => {
       }),
       {} as NonNullable<AddFormStepProps["stepThree"]>
     );
+  }, [watch, fields]);
+
+  // 3단계 '작성중' 태그 여부
+  useEffect(() => {
+    const subscription = watch((value, { name }) => {
+      if (name && fields.includes(name as (typeof fields)[number])) {
+        const currentValue = value[name as keyof typeof value];
+        if (currentValue && String(currentValue).trim() !== "") {
+          setStepActive(true);
+        }
+      }
+    });
+
+    return () => subscription.unsubscribe();
   }, [watch, fields]);
 
   // 임시 데이터 atom 업데이트

--- a/src/app/addform/components/StepTwoContents.tsx
+++ b/src/app/addform/components/StepTwoContents.tsx
@@ -65,7 +65,7 @@ const StepTwoContents = () => {
     });
 
     return () => subscription.unsubscribe();
-  }, [watch, fields]);
+  }, [watch, fields, setStepActive]);
 
   // 추출한 필수값을 폼에 적용
   useEffect(() => {

--- a/src/app/addform/components/Title.tsx
+++ b/src/app/addform/components/Title.tsx
@@ -10,6 +10,11 @@ const Title = () => {
   const handleCancel = () => {
     const isConfirm = confirm("작성을 취소하시겠습니까?"); // 모달 변경 필요
     if (isConfirm) {
+      const keys = ["stepOne", "stepTwo", "stepThree"];
+
+      keys.forEach((key) => {
+        localStorage.removeItem(key);
+      });
       router.push("/albalist");
     }
   };

--- a/src/app/addtalk/components/AddTalkForm.tsx
+++ b/src/app/addtalk/components/AddTalkForm.tsx
@@ -94,7 +94,7 @@ const AddTalkForm = () => {
 
       fetchData();
     }
-  }, [talkId]);
+  }, [talkId, addToast, setValue]);
 
   const onCancel = () => {
     router.push("/albatalk");

--- a/src/atoms/addFormAtomStore.ts
+++ b/src/atoms/addFormAtomStore.ts
@@ -14,8 +14,10 @@ export const addFormStepAtom = atom<AlbaformCreateStep>({
   stepNum: 1,
 });
 
+// 현재 이미지 리스트
 export const currentImageListAtom = atom<File[]>([]);
 
+// 임시 데이터
 export const temporaryDataByStepAtom = atom<AddFormStepProps>({});
 
 // 등록 버튼 클릭 시 트리거
@@ -29,3 +31,8 @@ export const addFormIsSubmittingAtom = atom<boolean>(false);
 
 // 2단계 메뉴 안겹치도록 관리
 export const stepTwoMenuOpenAtom = atom<string | null>(null);
+
+// 각 단계 작성중 여부
+export const stepActiveAtomFamily = atomFamily((step: string) =>
+  atom<boolean>(false)
+);


### PR DESCRIPTION
## 🧩 이슈 번호 #257

## 🔎 작업 내용
<!-- - 기능에서 어떤 부분이 구현되었는지 설명해주세요. -->
- 알바폼 만들기 PC화면의 '작성중' 태그를 값을 감지하여 값이 있을 때 뜨도록 했습니다.
- 수정하기를 통해 form이 나오면 모든 값이 있어야하는 상황이기에 세 단계에 모두 뜨도록 했습니다.

## 이미지 첨부
<!-- preview 이미지 혹 동영상을 첨부해주세요. -->
https://github.com/user-attachments/assets/1e474734-4a6d-4c53-a283-f06f9d896876

## 🔧 앞으로의 과제

<!-- - 이번 이슈에서 앞으로 남은 할 일을 적어주세요. -->
- 에러위치 수정

## 👩‍💻 공유 포인트 및 논의 사항

<!-- 공유하거나 논의할 사항을 작성해주세요. -->
- 이 로직 수정으로 addform 컴포넌트의 코드가 많이 길어졌습니다.
- 리팩토링의 필요성이 갈수록 커져서 리팩토링을 진행 후 에러위치를 수정하는 작업을 해보겠습니다.
