### PR TITLE
Fix: 알바 토크 글쓰기 및 상세 페이지 수정

### DIFF
--- a/src/app/addform/components/stepOne/AddformImage.tsx
+++ b/src/app/addform/components/stepOne/AddformImage.tsx
@@ -49,6 +49,7 @@ const AddformImage = () => {
         onImageChange={setCurrentImageList}
         initialImage={currentImageList}
         limit={3}
+        sizeCheck={true}
       />
     </div>
   );

--- a/src/app/addtalk/actions/addTalk.ts
+++ b/src/app/addtalk/actions/addTalk.ts
@@ -26,7 +26,7 @@ const addTalk = async (data: data) => {
 
   return {
     status: response.status,
-    data: response.data,
+    data: response,
   };
 };
 

--- a/src/app/addtalk/actions/patchPost.ts
+++ b/src/app/addtalk/actions/patchPost.ts
@@ -29,7 +29,7 @@ const patchPost = async (talkId: number, data: data) => {
 
   return {
     status: response.status,
-    data: response.data,
+    data: response,
   };
 };
 

--- a/src/app/addtalk/actions/uploadImage.ts
+++ b/src/app/addtalk/actions/uploadImage.ts
@@ -21,7 +21,7 @@ const uploadImage = async (file: File) => {
     };
   }
 
-  return { status: response.status, data: response.data.url };
+  return { status: response.status, data: response.url };
 };
 
 export default uploadImage;

--- a/src/app/addtalk/components/AddTalkForm.tsx
+++ b/src/app/addtalk/components/AddTalkForm.tsx
@@ -94,7 +94,7 @@ const AddTalkForm = () => {
 
       fetchData();
     }
-  }, [talkId, addToast, setValue]);
+  }, [talkId, setValue]);
 
   const onCancel = () => {
     router.push("/albatalk");

--- a/src/app/albatalks/[talkId]/actions/postComment.ts
+++ b/src/app/albatalks/[talkId]/actions/postComment.ts
@@ -30,7 +30,7 @@ const postComment = async ({
 
   return {
     status: response.status,
-    data: response.data,
+    data: response,
   };
 };
 

--- a/src/app/albatalks/[talkId]/getComments.ts
+++ b/src/app/albatalks/[talkId]/getComments.ts
@@ -18,13 +18,11 @@ const getComments = async (id: number, page: number, pageSize: number) => {
       };
     }
 
-    const { data, totalItemCount, currentPage, totalPages } = response.data;
-
     return {
-      data, // 댓글 리스트
-      totalItemCount, // 전체 댓글 수
-      currentPage, // 현재 페이지
-      totalPages, // 전체 페이지 수
+      data: response.data, // 댓글 리스트
+      totalItemCount: response.totalItemCount, // 전체 댓글 수
+      currentPage: response.currentPage, // 현재 페이지
+      totalPages: response.totalPages, // 전체 페이지 수
     };
   } catch (error) {
     console.error("댓글 목록을 조회하는데 실패했습니다.", error);

--- a/src/components/button/ImageInput.tsx
+++ b/src/components/button/ImageInput.tsx
@@ -14,11 +14,13 @@ interface ImageInputProps {
   limit?: number;
   onImageChange: (files: File[]) => void;
   initialImage?: File[];
+  sizeCheck?: boolean;
 }
 
 const ImageInput = ({
   size = "small",
   limit = 1,
+  sizeCheck = false,
   onImageChange,
   initialImage,
 }: ImageInputProps) => {
@@ -76,11 +78,13 @@ const ImageInput = ({
         }
 
         // 이미지 크기 확인
-        const imageCheck = await checkImageSize(file);
-        if (!imageCheck) {
-          isError = true;
-          setError("이미지 크기는 최소 1560 x 560이어야 합니다.");
-          continue;
+        if (sizeCheck) {
+          const imageCheck = await checkImageSize(file);
+          if (!imageCheck) {
+            isError = true;
+            setError("이미지 크기는 최소 1560 x 560이어야 합니다.");
+            continue;
+          }
         }
 
         const imageUrl = URL.createObjectURL(file);


### PR DESCRIPTION
## 🧩 이슈 번호 #326 #327 

## 🔎 작업 내용
- instance 업데이트로 인한 데이터의 return값 변경으로 기존의 response.data -> response로 return문 수정.
  - 글쓰기 및 수정 시 요청 실패 토스트를 띄우며 페이지 이동하지 않는 에러.
  - 댓글 목록 조회 에러.

- ImageInput **sizeCheck** prop 추가, 기본값은 false이며 true일 때 1560 x 560의 이미지 사이즈 검증하도록 수정. 
  ```
       // 예시입니다.

        <ImageInput
        limit={3}
        sizeCheck={true}
        onImageChange={setCurrentImageList}
        initialImage={currentImageList}
        />
   ```