### PR TITLE
Feat: 지원현황조회 모달 -> 각 지원자 클릭시 "지원자 상세 페이지"로 이동하는 기능

### DIFF
--- a/src/app/alba/[formId]/page.tsx
+++ b/src/app/alba/[formId]/page.tsx
@@ -62,8 +62,6 @@ const AlbarformDetailPage = async ({ params }: PageProps) => {
     );
   }
 
-  console.log("스크랩되었나요?", data.isScrapped);
-
   return (
     <>
       {data.imageUrls && <Carousel imageUrls={data.imageUrls} />}

--- a/src/components/ApplicantStatsList.tsx
+++ b/src/components/ApplicantStatsList.tsx
@@ -7,7 +7,7 @@ import formatExperienceMonth from "@/utils/formatExperienceMonth";
 import translateStatus from "@/utils/translateStatus";
 import LoadingSpinner from "./spinner/LoadingSpinner";
 import { useEffect, useState } from "react";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 
 interface ApplicantData {
   applicantId: number;
@@ -24,6 +24,7 @@ interface ApplicantData {
 }
 
 const ApplicantStatsList = () => {
+  const router = useRouter();
   const [list, setList] = useState<ApplicantData[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [orderExperience, setOrderExperience] = useState<"asc" | "desc">("asc");
@@ -37,7 +38,7 @@ const ApplicantStatsList = () => {
         const res = await instance(
           `${process.env.NEXT_PUBLIC_API_URL}/forms/${formId}/applications?limit=10&orderExperience=${orderExperience}&orderByStatus=${orderByStatus}`
         );
-        setList(res.data.data);
+        setList(res.data);
         setIsLoading(false);
       } catch (error) {
         console.error("지원자 현황 조회에 실패했습니다", error);
@@ -45,6 +46,8 @@ const ApplicantStatsList = () => {
     };
     fetchApplicantList();
   }, [formId, orderExperience, orderByStatus]);
+
+  console.log("지원자 리스트:", list);
 
   const toggleSortButton = (mode: string) => {
     if (mode === "experience")
@@ -107,7 +110,8 @@ const ApplicantStatsList = () => {
                   list.map((el) => (
                     <tr
                       key={el.id}
-                      className="h-[72px] w-[375px] border-t border-t-line-100 text-left pc:text-xl"
+                      className="h-[72px] w-[375px] cursor-pointer border-t border-t-line-100 text-left hover:text-orange-300 pc:text-xl"
+                      onClick={() => router.push(`/applications/${el.id}`)}
                     >
                       <td className="pl-4 underline">{el.name}</td>
                       <td className="pl-5">


### PR DESCRIPTION
## 🧩 이슈 번호 #338 

## 🔎 작업 내용
- 사장님 전용 "지원 현황 조회" 모달에서 지원자 누를 경우 지원자 상세 페이지로 이동시키는 기능입니다.

## 이미지 첨부
https://github.com/user-attachments/assets/ba84e4d4-7e8c-4e27-a65f-7eaa2a0aff0d

## 🔧 앞으로의 과제
- 사장님 전용 "지원자 상세 페이지" 만들어야 합니다.
- 사장님 전용이지만 페이지 ui는 "내 지원 상세 페이지"와 같기에 추측컨데 기존에 만들어 둔 페이지 컴포넌트를 재활용할 수 있어야 할 것 같습니다..

## 👩‍💻 공유 포인트 및 논의 사항
- 지원자 전용 "내 지원 상세 페이지"와 사장님 전용 "지원자 상세 패이지"의 ui가 같은데 url은 서로 다릅니다.(/myapply/{formId}) <-> (/application/{applicationId}) 
- ui는 같지만 url이 서로 다를때 어떻게 해야 효율적으로 컴포넌트를 렌더링 할 수 있을지가 키포인트인 것 같습니다!
