### PR TITLE
Refactor: 알바폼 상세페이지

### DIFF
--- a/src/app/alba/[formId]/fetchAlbaformData.ts
+++ b/src/app/alba/[formId]/fetchAlbaformData.ts
@@ -1,11 +1,13 @@
-const fetchData = async (formId: string) => {
+const fetchAlbaformData = async (formId: string) => {
   const API_URL = process.env.NEXT_PUBLIC_API_URL;
 
   if (!API_URL) {
     throw new Error("API URL이 env파일에 정의되어 있지 않습니다.");
   }
 
-  const response = await fetch(`${API_URL}/forms/${formId}`);
+  const response = await fetch(`${API_URL}/forms/${formId}`, {
+    next: { revalidate: 60 * 5 },
+  });
   if (!response.ok) {
     throw new Error(`데이터 요청에 실패했습니다.: ${response.statusText}`);
   }
@@ -14,4 +16,4 @@ const fetchData = async (formId: string) => {
   return data;
 };
 
-export default fetchData;
+export default fetchAlbaformData;

--- a/src/app/alba/[formId]/page.tsx
+++ b/src/app/alba/[formId]/page.tsx
@@ -62,11 +62,9 @@ const AlbarformDetailPage = async ({ params }: PageProps) => {
     );
   }
 
-  console.log("스크랩되었나요?", data.isScrapped);
-
   return (
     <>
-      {data.imageUrls && <Carousel imageUrls={data.imageUrls} />}
+      <Carousel imageUrls={data.imageUrls} />
       <div className="mt-8 grid gap-[32px] pc:mt-[80px] pc:grid-cols-[770px_640px] pc:grid-rows-[432px_336px_230px_562px] pc:justify-items-center pc:gap-0 pc:gap-x-[150px] pc:gap-y-[40px] pc:grid-areas-layout tablet:w-[550px] tablet:grid-cols-1 tablet:grid-rows-[270px_220px_156px_396px_302px_340px_158px] mobile:w-[327px] mobile:grid-cols-1 mobile:grid-rows-[270px_116px_156px_396px_302px_340px_158px]">
         <section className="self-center pc:grid-in-box1">
           <Title info={data} />

--- a/src/app/alba/[formId]/page.tsx
+++ b/src/app/alba/[formId]/page.tsx
@@ -1,9 +1,9 @@
 import Carousel from "@/components/Carousel/Carousel";
-import fetchData from "./fetchData";
+import fetchAlbaformData from "./fetchAlbaformData";
 import Content from "./components/Content";
 import Title from "./components/Title";
-import StoreLocation from "./components/StoreLocation";
 import SimpleRequirements from "./components/SimpleRequirements";
+import StoreLocation from "./components/StoreLocation";
 import EmployerInfo from "./components/EmployerInfo";
 import DetailRequirements from "./components/DetailRequirements";
 import NoticeApplicant from "./components/NoticeApplicant";
@@ -11,8 +11,8 @@ import NoticeIsClosed from "./components/NoticeIsClosed";
 import ScrapAndShareButton from "./components/ScrapAndShareButton";
 import ApllicantActionButtons from "./components/ApllicantActionButtons";
 import OwnerActionButtons from "./components/OwnerActionButtons";
-import { AlbaformDetailData } from "@/types/alba";
 import { cookies } from "next/headers";
+import { AlbaformDetailData } from "@/types/alba";
 import { cls } from "@/utils/dynamicTailwinds";
 
 type PageProps = {
@@ -22,7 +22,7 @@ type PageProps = {
 export const generateMetadata = async ({ params }: PageProps) => {
   const { formId } = await params;
 
-  const data: AlbaformDetailData = await fetchData(formId);
+  const data: AlbaformDetailData = await fetchAlbaformData(formId);
 
   return {
     title: "알바폼 상세페이지",
@@ -49,7 +49,7 @@ const AlbarformDetailPage = async ({ params }: PageProps) => {
   const { formId } = await params;
 
   try {
-    data = await fetchData(formId);
+    data = await fetchAlbaformData(formId);
     isMyAlbarform = Number(userId) === data.ownerId;
   } catch (error) {
     console.error(error);

--- a/src/components/Carousel/Carousel.tsx
+++ b/src/components/Carousel/Carousel.tsx
@@ -26,7 +26,12 @@ const Carousel = ({ imageUrls }: { imageUrls: string[] }) => {
             isRenderingIndex === index ? "opacity-100" : "opacity-0"
           )}
         >
-          <Image src={imageUrl} fill alt="캐러샐 이미지" />
+          <Image
+            src={imageUrl || "/logo/albaform.svg"}
+            fill
+            alt="캐러샐 이미지"
+            priority={index === 0}
+          />
         </figure>
       ))}
       {/* 인디케이터 */}

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -22,8 +22,6 @@ const Header = () => {
     setIsLogin(!!loginStatus);
   }, []);
 
-  console.log(isLogin);
-
   const tabletStyle =
     "tablet:h-[60px] tablet:gap-[24px] tablet:px-[72px] tablet:py-[15px] tablet:text-lg";
   const pcStyle =

--- a/src/components/header/Logo.tsx
+++ b/src/components/header/Logo.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import useViewPort from "@/hooks/useViewport";
 import Image from "next/image";
 import Link from "next/link";
@@ -16,6 +18,7 @@ const Logo = () => {
           }
           fill
           alt="logo"
+          loading="eager"
         />
       </Link>
     </h1>


### PR DESCRIPTION
## 🧩 이슈 번호 #342 

## 🔎 작업 내용
- 페이지 컴포넌트에서 데이터 패칭할때 5분동안 캐싱되도록 수정했습니다.
- 헤더에 로고와 페이지에 캐러셀 같은 경우 핵심적인 시각적 요소라고 판단하여 next/Image의 기본 값인 lazy loading이 아닌 loading="eager" 또는 priority를 명시해주었습니다
> 페이지가 로드되자마자 보이는 컨텐츠라면 어차피 바로 감지되었다고 인식하기 떄문에 그 차이가 미비하지만 lazy-loading은 브라우저에 감지되었는가를 확인할 때 observer api를 호출하기 때문에 그 부분에서 미세한 차이가 있을 수 있다고 이야기합니다! 맹신할 수 없는 지표이지만 실제로 넣고 안 넣었을 떄 lighthouse에서 80대에서 90대까지 올라가는 모습이었습니다!

## 이미지 첨부
![image](https://github.com/user-attachments/assets/68aea222-c59c-4fde-8de6-ee6c9287b121)

## 🔧 앞으로의 과제
- [ ] 나의 지원 상세 페이지 페이지 성능 체크하기
- [ ] 지원자 상세 페이지 성능 체크하기

