### PR TITLE
Chore:비회원 정보 전역상태로 저장

### DIFF
--- a/src/atoms/nonMemberInfoAtom.ts
+++ b/src/atoms/nonMemberInfoAtom.ts
@@ -1,0 +1,15 @@
+import { atom } from "jotai";
+
+export const nonMemberInfoAtom = atom({
+  id: 0,
+  name: "",
+  phoneNumber: "",
+  experienceMonths: 0,
+  resumeId: 0,
+  resumeName: "",
+  introduction: "",
+  status: "",
+  createdAt: "",
+  updatedAt: "",
+  applicantId: null,
+});

--- a/src/components/modal/modalContent/GetMyApplicationModal.tsx
+++ b/src/components/modal/modalContent/GetMyApplicationModal.tsx
@@ -14,12 +14,15 @@ import { useModal } from "@/hooks/useModal";
 import { useParams, useRouter } from "next/navigation";
 import { getMyApplicationAction } from "../modalActions/getMyApplicationAction";
 import { useToast } from "@/hooks/useToast";
+import { useSetAtom } from "jotai";
+import { nonMemberInfoAtom } from "@/atoms/nonMemberInfoAtom";
 
 const GetMyApplicationModal = () => {
   const { closeModal } = useModal();
   const { addToast } = useToast();
   const [visible, setVisible] = useState(false);
   const [loading, setLoading] = useState(false);
+  const setNonMemberInfo = useSetAtom(nonMemberInfoAtom);
   const router = useRouter();
   const params = useParams();
   const formId = params.formId as string;
@@ -48,6 +51,7 @@ const GetMyApplicationModal = () => {
       const response = await getMyApplicationAction(formData, formId);
 
       if (response.status === 200) {
+        setNonMemberInfo(response.data);
         closeModal();
 
         router.push(`/myapply/${formId}`); //지원 상세 조회 페이지로 이동


### PR DESCRIPTION
## 🧩 이슈 번호 #313 

## 🔎 작업 내용
비회원일때 "내 지원 내역 조회" -> 데이터 패칭 후 얻은 데이터를 nonMemberInfoAtom에 저장

`const [nonMemberInfo, setNonMemberInfo] = useAtom(nonMemberInfoAtom);`




