### PR TITLE
Fix: 알바폼상세페이지에서 지원자일 때 ActionButton이 이상하게 배치되는 문제 해결

### DIFF
--- a/src/app/alba/[formId]/page.tsx
+++ b/src/app/alba/[formId]/page.tsx
@@ -44,7 +44,7 @@ const AlbarformDetailPage = async ({ params }: PageProps) => {
   let data: AlbaformDetailData;
   let isMyAlbarform: boolean;
   const cookie = await cookies();
-  const role = cookie.get("role")?.value || "defaultRole";
+  const role = cookie.get("role")?.value || "nonMember";
   const userId = cookie.get("id")?.value;
   const { formId } = await params;
 
@@ -79,28 +79,36 @@ const AlbarformDetailPage = async ({ params }: PageProps) => {
           <Content description={data.description} />
         </section>
         <section
-          className={cls(isMyAlbarform ? "pc:grid-in-box7" : "pc:grid-in-box6")}
+          className={
+            role === "APPLICANT" || role === "nonMember"
+              ? "pc:grid-in-box7"
+              : isMyAlbarform
+                ? "pc:grid-in-box7"
+                : "pc:grid-in-box6"
+          }
         >
           <DetailRequirements info={data} />
         </section>
         <section className="pc:grid-in-box3">
           <StoreLocation location={data.location} />
         </section>
-        <section
-          className={cls(
-            "flex w-full flex-col gap-[10px]",
-            isMyAlbarform ? "pc:grid-in-box6" : ""
-          )}
-        >
-          {role === "APPLICANT" ? (
+        {role === "APPLICANT" || role === "nonMember" ? (
+          <section className="flex w-full flex-col gap-[10px] pc:grid-in-box6">
             <ApllicantActionButtons
               formId={formId}
               recruitmentEndDate={data.recruitmentEndDate}
             />
-          ) : isMyAlbarform ? (
+          </section>
+        ) : isMyAlbarform ? (
+          <section
+            className={cls(
+              "flex w-full flex-col gap-[10px]",
+              isMyAlbarform ? "pc:grid-in-box6" : ""
+            )}
+          >
             <OwnerActionButtons formId={formId} />
-          ) : null}
-        </section>
+          </section>
+        ) : null}
       </div>
       <NoticeApplicant count={data.applyCount} />
       <NoticeIsClosed closedDate={data.recruitmentEndDate} />

--- a/src/app/alba/components/ApllicantActionButtons.tsx
+++ b/src/app/alba/components/ApllicantActionButtons.tsx
@@ -18,6 +18,7 @@ const ApllicantActionButtons = ({
   const [disabled, setDisabled] = useState(false);
   const router = useRouter();
   const { openModal } = useModal();
+  const isLogin = localStorage.getItem("isLogin");
 
   useEffect(() => {
     if (isPast(recruitmentEndDate)) setDisabled(true);
@@ -36,7 +37,11 @@ const ApllicantActionButtons = ({
       <SolidButton
         icon="/icon/document-md.svg"
         style="outOrange300"
-        onClick={() => openModal("GetMyApplicationModal")}
+        onClick={
+          isLogin
+            ? () => router.push(`/myapply/${formId}`)
+            : () => openModal("GetMyApplicationModal")
+        }
       >
         내 지원 내역 보기
       </SolidButton>


### PR DESCRIPTION
## 🧩 이슈 번호 #231 

## 🔎 작업 내용
- 알바폼상세페이지에서 자기 폼이 아닐 때 ActionButtons가 렌더링 되지 않게 할려고 isMyAlbaform이라는 사장님 전용 변수를 만들어놨는데 이것이 지원자 전용일 떄에도 영향을 줘서 서로 영향을 주지 않게 분기처리 했습니다.
- 지원자가 로그인하고 알바폼 상세페이지로 들어가 "내 지원 내역 보기" 버튼을 눌렀을 때 기존에는 모달이 떴는데 이번에는 바로 /myapply/{formId}로 보내게 했습니다. 로컬 스토리지에 isLogin이 있는지 없는지로 구분했습니다.