### PR TITLE
Chore: 비회원이 접근할 수 없는 페이지 접근되는 현상 수정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import Sidebar from "@/components/header/Sidebar";
 import ModalManager from "@/components/modal/modalManager/ModalManager";
 import ToastContainer from "@/components/toast/ToastContainer";
 import Script from "next/script";
+import RedirectWarning from "@/lib/RedirectWarning";
 
 export const metadata: Metadata = {
   title: {
@@ -33,6 +34,7 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body>
+        <RedirectWarning />
         <Sidebar />
         <Header />
         <ModalManager />

--- a/src/lib/RedirectWarning.tsx
+++ b/src/lib/RedirectWarning.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useToast } from "@/hooks/useToast";
+import { usePathname, useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+const RedirectWarning = () => {
+  const { addToast } = useToast();
+  const pathname = usePathname();
+  const router = useRouter();
+
+  useEffect(() => {
+    const currentParams = new URLSearchParams(window.location.search);
+    const signinError = currentParams.get("nonMemberError");
+    const roleError = currentParams.get("roleError");
+
+    if (signinError) {
+      addToast("해당 페이지로 이동하시려면 로그인이 필요합니다.", "warning");
+    } else if (roleError) {
+      addToast("해당 페이지로 이동하시려면 권한이 필요합니다.", "warning");
+    }
+
+    currentParams.delete("nonMemberError");
+    currentParams.delete("roleError");
+    router.replace(`${pathname}?${currentParams.toString()}`);
+  }, [addToast, pathname, router]);
+
+  return null;
+};
+
+export default RedirectWarning;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,14 +6,14 @@ export const middleware = async (request: NextRequest) => {
   const path = url.pathname;
   const role = request.cookies.get("role");
   const referer = request.headers.get("referer");
-  const ownerPath = [
-    "/owner",
-    "/addform",
-    "/addform/",
-    "/applications/",
+  const ownerPath = ["/owner", "/addform", "/addform/", "/applications/"];
+  const applicantPath = ["/applicant", "/apply/"];
+  const allAuthPath = [
+    ...ownerPath,
+    ...applicantPath,
+    "/mypage",
     "/myalbaform",
   ];
-  const applicantPath = ["/applicant", "/apply/", "/myapply/", "/mypage"];
   const accessToken = request.cookies.get("accessToken");
 
   // 액세스토큰 만료 시 리프레시토큰으로 액세스토큰 재발급 후 요청 재전송
@@ -45,41 +45,45 @@ export const middleware = async (request: NextRequest) => {
     }
   }
 
+  // searchParams 설정
+  const redirectSearchParams = (prevUrl: string | URL) => {
+    const errorUrl = new URL(prevUrl);
+
+    if (!role && !accessToken) {
+      errorUrl.searchParams.set("nonMemberError", "signinError");
+    } else {
+      errorUrl.searchParams.set("roleError", "roleError");
+    }
+    return errorUrl;
+  };
+
   // 사장님용 페이지
   if (role && role.value === "APPLICANT" && ownerPath.includes(path)) {
-    // const prevUrl = referer || url.origin;
-    // const errorUrl = new URL(prevUrl);
-    // errorUrl.searchParams.set("error", "matchErrror");
-
-    if (referer) {
-      return NextResponse.redirect(referer);
-    } else {
-      return NextResponse.redirect(url.origin);
-    }
+    return NextResponse.redirect(redirectSearchParams(referer || url.origin));
   }
 
   // 지원자용 페이지
   if (role && role.value === "OWNER" && applicantPath.includes(path)) {
-    // const prevUrl = referer || url.origin;
-    // const errorUrl = new URL(prevUrl);
-    // errorUrl.searchParams.set("error", "matchErrror");
-
-    if (referer) {
-      return NextResponse.redirect(referer);
-    } else {
-      return NextResponse.redirect(url.origin);
-    }
+    return NextResponse.redirect(redirectSearchParams(referer || url.origin));
   }
 
   // 비회원이 전용페이지 접근하는 것을 차단
   if (!role && !accessToken) {
-    const isOwnerPath = ownerPath.some((path) => url.pathname.startsWith(path));
-    const isApplicantPath = applicantPath.some((path) =>
-      url.pathname.startsWith(path)
-    );
-    if (isOwnerPath || isApplicantPath) {
-      return NextResponse.redirect(new URL("/signin/applicant", request.url));
+    if (path.startsWith("/signin")) {
+      return NextResponse.next();
     }
+
+    if (allAuthPath.some((authPath) => path.startsWith(authPath))) {
+      if (ownerPath.some((ownerRoute) => path.startsWith(ownerRoute))) {
+        return NextResponse.redirect(
+          redirectSearchParams(new URL("/signin/owner", request.url))
+        );
+      }
+      return NextResponse.redirect(
+        redirectSearchParams(new URL("/signin/applicant", request.url))
+      );
+    }
+    return NextResponse.next();
   }
 
   // 로그인되어 있으면 로그인페이지로 못가도록 막음

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,8 +6,14 @@ export const middleware = async (request: NextRequest) => {
   const path = url.pathname;
   const role = request.cookies.get("role");
   const referer = request.headers.get("referer");
-  const ownerPath = ["/owner", "/addform", "/addform/", "/applications/"];
-  const applicantPath = ["/applicant", "/apply/", "/myapply/"];
+  const ownerPath = [
+    "/owner",
+    "/addform",
+    "/addform/",
+    "/applications/",
+    "/myalbaform",
+  ];
+  const applicantPath = ["/applicant", "/apply/", "/myapply/", "/mypage"];
   const accessToken = request.cookies.get("accessToken");
 
   // 액세스토큰 만료 시 리프레시토큰으로 액세스토큰 재발급 후 요청 재전송
@@ -67,7 +73,11 @@ export const middleware = async (request: NextRequest) => {
 
   // 비회원이 전용페이지 접근하는 것을 차단
   if (!role && !accessToken) {
-    if (ownerPath.includes(path) || applicantPath.includes(path)) {
+    const isOwnerPath = ownerPath.some((path) => url.pathname.startsWith(path));
+    const isApplicantPath = applicantPath.some((path) =>
+      url.pathname.startsWith(path)
+    );
+    if (isOwnerPath || isApplicantPath) {
       return NextResponse.redirect(new URL("/signin/applicant", request.url));
     }
   }


### PR DESCRIPTION
## 🧩 이슈 번호 #364 #380

## 🔎 작업 내용
<!-- - 기능에서 어떤 부분이 구현되었는지 설명해주세요. -->
- 비회원이 접근할 수 없는 페이지에 접근할 수 있었던 현상을 수정했습니다.
- 리다이렉트 되면 토스트가 띄워지도록 했습니다.

## 이미지 첨부
<!-- preview 이미지 혹 동영상을 첨부해주세요. -->
https://github.com/user-attachments/assets/7fd734e7-bdc3-4831-bdab-587ae8980251

## 🔧 앞으로의 과제

<!-- - 이번 이슈에서 앞으로 남은 할 일을 적어주세요. -->
- 없음

## 👩‍💻 공유 포인트 및 논의 사항

<!-- 공유하거나 논의할 사항을 작성해주세요. -->
- 기존에 ownerPath.includes(path) 이런식으로 설정해놨었는데, 이는 path에 해당되는 정확한 URL일 때만 해당된다고 합니다.
- 그래서 path.startsWith로 ownerPath와 applicantPath에 속하는 URL로 들어가면 로그인페이지로 이동하도록 했습니다.
- 비회원일 떄 뜨는 토스트내용, 회원인데 전용페이지로 들어갔을 경우의 토스트내용이 서로 다르게 했습니다.
