### PR TITLE
Chore: 알바폼 수정하기로 들어갔을 때 임시저장데이터 불러오지 않도록 수정

### DIFF
--- a/src/app/addform/[id]/page.tsx
+++ b/src/app/addform/[id]/page.tsx
@@ -19,7 +19,7 @@ const EditFormPage = async ({ params }: EditFormPageProps) => {
         `${process.env.NEXT_PUBLIC_API_URL}/forms/${id}`,
         {
           method: "GET",
-          cache: "force-cache",
+          next: { tags: ["albaformEdit"] },
         }
       );
 

--- a/src/app/addform/components/MainButton.tsx
+++ b/src/app/addform/components/MainButton.tsx
@@ -9,6 +9,7 @@ import { useAddForm } from "@/hooks/useAddForm";
 import { useValidateForm } from "@/hooks/useAddForm";
 import { useToast } from "@/hooks/useToast";
 import { useAtomValue, useSetAtom } from "jotai";
+import { revalidateTag } from "next/cache";
 import { useParams } from "next/navigation";
 
 const MainButton = () => {
@@ -35,6 +36,11 @@ const MainButton = () => {
     addToast("입력한 내용이 임시 저장되었습니다.", "success");
   };
 
+  const handleEdit = () => {
+    setAddFormSubmitTrigger(true);
+    revalidateTag("albarformDetail");
+  };
+
   return (
     <div className="flex flex-col space-y-2 p-6">
       {!params.id ? (
@@ -55,7 +61,7 @@ const MainButton = () => {
         <SolidButton
           type="submit"
           style="orange300"
-          onClick={() => setAddFormSubmitTrigger(true)}
+          onClick={handleEdit}
           disabled={submitDisabled || addFormIsSubmitting}
         >
           {addFormIsSubmitting ? "수정중..." : "수정하기"}

--- a/src/app/addform/components/StepContainer.tsx
+++ b/src/app/addform/components/StepContainer.tsx
@@ -9,7 +9,7 @@ import {
   currentImageListAtom,
   addFromSubmitTriggerAtom,
 } from "@/atoms/addFormAtomStore";
-import { useAtom, useAtomValue } from "jotai";
+import { useAtom } from "jotai";
 import { handleDateRangeFormat } from "@/utils/formatAddFormDate";
 import { addFormImgUpload } from "../actions/addFormImgUpload";
 import { useToast } from "@/hooks/useToast";
@@ -53,8 +53,10 @@ const StepContainer = ({ albaForm, formId }: StepContainerProps) => {
 
   // 마운트 시 전체 임시저장 데이터 가져오기
   useEffect(() => {
-    loadAllTempData();
-  }, [loadAllTempData]);
+    if (!isEdit) {
+      loadAllTempData();
+    }
+  }, [loadAllTempData, isEdit]);
 
   // 새로 쓰기 버튼 클릭 시 전체 임시저장 데이터 초기화
   useEffect(() => {
@@ -177,7 +179,7 @@ const StepContainer = ({ albaForm, formId }: StepContainerProps) => {
   return (
     <FormProvider {...methods}>
       <form onSubmit={methods.handleSubmit(onSubmit)} className="p-6">
-        <StepContent step={step} />
+        <StepContent step={step} isEdit={isEdit} />
       </form>
     </FormProvider>
   );

--- a/src/app/addform/components/StepContent.tsx
+++ b/src/app/addform/components/StepContent.tsx
@@ -2,7 +2,13 @@ import StepOneContents from "./StepOneContents";
 import StepThreeContents from "./StepThreeContents";
 import StepTwoContents from "./StepTwoContents";
 
-const StepContent = ({ step }: { step: string }) => {
+const StepContent = ({
+  step,
+  isEdit,
+}: {
+  step: string;
+  isEdit: boolean | undefined;
+}) => {
   const componentsByStep = {
     stepOne: StepOneContents,
     stepTwo: StepTwoContents,
@@ -11,7 +17,7 @@ const StepContent = ({ step }: { step: string }) => {
 
   const Component = componentsByStep[step as keyof typeof componentsByStep];
 
-  return Component ? <Component /> : null;
+  return Component ? <Component isEdit={isEdit} /> : null;
 };
 
 export default StepContent;

--- a/src/app/addform/components/StepOneContents.tsx
+++ b/src/app/addform/components/StepOneContents.tsx
@@ -18,7 +18,7 @@ import {
 } from "@/hooks/useAddFormStepOne";
 import { newWriteAtom } from "@/atoms/newWrite";
 
-const StepOneContents = () => {
+const StepOneContents = ({ isEdit }: { isEdit: boolean | undefined }) => {
   const { watch, setValue, stepOneData, fields } = useAddFormStepOne();
   const [currentImageList, setCurrentImageList] = useAtom(currentImageListAtom);
   const setTemporaryDataByStep = useSetAtom(temporaryDataByStepAtom);
@@ -49,6 +49,11 @@ const StepOneContents = () => {
 
   // 임시 데이터 있으면 로컬스토리지에서 불러오기
   useEffect(() => {
+    if (isEdit) {
+      setLoading(false);
+      return;
+    }
+
     if (isNewWrite) {
       fields.forEach((field) => {
         setValue(field, "");
@@ -93,6 +98,7 @@ const StepOneContents = () => {
     loadFromLocalStorage,
     isNewWrite,
     setTemporaryDataByStep,
+    isEdit,
   ]);
 
   if (loading) {

--- a/src/app/addform/components/StepThreeContents.tsx
+++ b/src/app/addform/components/StepThreeContents.tsx
@@ -16,7 +16,7 @@ import { useEffect, useMemo, useState } from "react";
 import { AddFormStepProps } from "@/types/addform";
 import LoadingSkeleton from "./LoadingSkeleton";
 
-const StepThreeContents = () => {
+const StepThreeContents = ({ isEdit }: { isEdit: boolean | undefined }) => {
   const { watch, setValue } = useFormContext<z.infer<typeof addFormSchema>>();
   const setTemporaryDataByStep = useSetAtom(temporaryDataByStepAtom);
   const setStepActive = useSetAtom(stepActiveAtomFamily("stepThree"));
@@ -73,6 +73,11 @@ const StepThreeContents = () => {
 
   // 임시 데이터 로컬스토리지에서 불러오기
   useEffect(() => {
+    if (isEdit) {
+      setLoading(false);
+      return;
+    }
+
     const localStorageData = localStorage.getItem("stepThree");
     if (localStorageData) {
       const data = JSON.parse(localStorageData);
@@ -81,7 +86,7 @@ const StepThreeContents = () => {
       });
     }
     setLoading(false);
-  }, [setValue, fields]);
+  }, [setValue, fields, isEdit]);
 
   if (loading) {
     return <LoadingSkeleton count={5} />;

--- a/src/app/addform/components/StepTwoContents.tsx
+++ b/src/app/addform/components/StepTwoContents.tsx
@@ -10,7 +10,7 @@ import {
 import { useSetAtom } from "jotai";
 import LoadingSkeleton from "./LoadingSkeleton";
 
-const StepTwoContents = () => {
+const StepTwoContents = ({ isEdit }: { isEdit: boolean | undefined }) => {
   const {
     setValue,
     getValues,
@@ -89,6 +89,11 @@ const StepTwoContents = () => {
 
   // 임시 데이터 있으면 로컬스토리지에서 불러오기
   useEffect(() => {
+    if (isEdit) {
+      setLoading(false);
+      return;
+    }
+
     const localStorageData = localStorage.getItem("stepTwo");
     if (localStorageData) {
       const parsedData = JSON.parse(localStorageData);
@@ -99,7 +104,7 @@ const StepTwoContents = () => {
       setStepTwoData(parsedData);
     }
     setLoading(false);
-  }, [setValue, setStepTwoData, fields]);
+  }, [setValue, setStepTwoData, fields, isEdit]);
 
   if (loading) {
     return <LoadingSkeleton count={5} />;

--- a/src/app/alba/[formId]/components/OwnerActionButtons.tsx
+++ b/src/app/alba/[formId]/components/OwnerActionButtons.tsx
@@ -2,11 +2,17 @@
 
 import SolidButton from "@/components/button/SolidButton";
 import { useModal } from "@/hooks/useModal";
+import { revalidateTag } from "next/cache";
 import { useRouter } from "next/navigation";
 
 const OwnerActionButtons = ({ formId }: { formId: string }) => {
   const router = useRouter();
   const { openModal } = useModal();
+
+  const handleEdit = () => {
+    router.push(`/addform/${formId}`);
+    revalidateTag("albaformEdit");
+  };
 
   return (
     <>
@@ -20,7 +26,7 @@ const OwnerActionButtons = ({ formId }: { formId: string }) => {
       <SolidButton
         icon="/icon/write-lg.svg"
         style="orange300"
-        onClick={() => router.push(`/addform/${formId}`)}
+        onClick={handleEdit}
       >
         수정하기
       </SolidButton>

--- a/src/app/alba/[formId]/fetchAlbarformDetailData.ts
+++ b/src/app/alba/[formId]/fetchAlbarformDetailData.ts
@@ -6,7 +6,7 @@ const fetchAlbarformDetailData = async (formId: string) => {
   }
 
   const response = await fetch(`${API_URL}/forms/${formId}`, {
-    next: { revalidate: 60 * 5 },
+    next: { tags: ["albarformDetail"] },
   });
   if (!response.ok) {
     throw new Error(`데이터 요청에 실패했습니다.: ${response.statusText}`);


### PR DESCRIPTION
## 🧩 이슈 번호 #363 #381

## 🔎 작업 내용
<!-- - 기능에서 어떤 부분이 구현되었는지 설명해주세요. -->
- 임시저장 데이터가 로컬스토리지에 있더라도 수정하기 페이지로 들어가면 불러오지 않도록 수정했습니다.
- 알바폼을 수정하면 상세페이지에서 바로 반영되도록 수정했습니다.
- 알바폼을 수정하면 수정하기페이지에서 바로 반영되도록 수정했습니다.

## 이미지 첨부
<!-- preview 이미지 혹 동영상을 첨부해주세요. -->
https://github.com/user-attachments/assets/7297186d-cf3f-4bb8-8660-355a4f4cf7bf
https://github.com/user-attachments/assets/7170eeeb-fb2c-4643-9621-71fe57b0cec2

## 🔧 앞으로의 과제

<!-- - 이번 이슈에서 앞으로 남은 할 일을 적어주세요. -->
- 없음

## 👩‍💻 공유 포인트 및 논의 사항

<!-- 공유하거나 논의할 사항을 작성해주세요. -->
- 알바폼 수정 후 알바폼 상세페이지에 반영되기까지 시간이 걸립니다.
- 알바폼 상세페이지가 캐싱된 상태여서 revalidate로 정한 시간이 되서야 새로 업데이트되는 문제였습니다.
- 그래서 revalidate에 tag를 설정하여 수정되면 즉시 반영되도록 했습니다.
- 수정하기페이지에서 업데이트되지 않는 부분 역시 tag를 사용하여 수정했습니다.
