### PR TITLE
Feat:PostCard 썸네일 추가

### DIFF
--- a/src/components/PostCardThumbnail.tsx
+++ b/src/components/PostCardThumbnail.tsx
@@ -3,12 +3,9 @@ import Image from "next/image";
 const PostCardThumbnail = ({ imageUrl }: { imageUrl: string }) => {
   return (
     <div className="relative h-[100px] w-[100px] overflow-hidden rounded-md pc:h-[150px] pc:w-[150px]">
-      <Image
-        src={imageUrl ? imageUrl : "/icon/profile-lg.svg"}
-        fill
-        className="object-cover"
-        alt="썸네일"
-      />
+      {imageUrl && (
+        <Image src={imageUrl} fill className="object-cover" alt="썸네일" />
+      )}
     </div>
   );
 };

--- a/src/components/PostCardThumbnail.tsx
+++ b/src/components/PostCardThumbnail.tsx
@@ -1,0 +1,16 @@
+import Image from "next/image";
+
+const PostCardThumbnail = ({ imageUrl }: { imageUrl: string }) => {
+  return (
+    <div className="relative h-[100px] w-[100px] overflow-hidden rounded-md pc:h-[150px] pc:w-[150px]">
+      <Image
+        src={imageUrl ? imageUrl : "/icon/profile-lg.svg"}
+        fill
+        className="object-cover"
+        alt="썸네일"
+      />
+    </div>
+  );
+};
+
+export default PostCardThumbnail;

--- a/src/components/card/PostCard.tsx
+++ b/src/components/card/PostCard.tsx
@@ -8,6 +8,7 @@ import UserInfoInCard from "../UserInfoInCard";
 import { PostCardProps } from "@/types/post";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import PostCardThumbnail from "../PostCardThumbnail";
 
 const PostCard = ({ info }: { info: PostCardProps }) => {
   const [isHover, setIsHover] = useState(false);
@@ -21,12 +22,16 @@ const PostCard = ({ info }: { info: PostCardProps }) => {
         onMouseEnter={() => setIsHover(true)}
         onMouseLeave={() => setIsHover(false)}
       >
-        <h3 className="w-[80%] font-semibold text-black-400 pc:text-2lg">
+        <h3 className="w-[80%] truncate font-semibold text-black-400 pc:w-[60%] pc:text-2lg">
           {info.title}
         </h3>
-        <p className="mt-2 line-clamp-2 h-[48px] w-[80%] text-md text-gray-500 pc:-mt-[60px] pc:text-lg">
+        <p className="t-gray-500 mt-2 line-clamp-2 h-[48px] w-[80%] pc:-mt-[60px] pc:w-[60%] pc:text-lg">
           {info.content}
         </p>
+        <div className="absolute right-3 top-3 pc:right-6 pc:top-6">
+          <PostCardThumbnail imageUrl={info.imageUrl} />
+        </div>
+
         <div className="mt-[20px] flex items-center justify-between gap-2 text-xs not-italic text-gray-500 pc:text-lg">
           <UserInfoInCard
             image={info.writer.imageUrl}

--- a/src/components/card/PostCard.tsx
+++ b/src/components/card/PostCard.tsx
@@ -25,7 +25,7 @@ const PostCard = ({ info }: { info: PostCardProps }) => {
         <h3 className="w-[80%] truncate font-semibold text-black-400 pc:w-[60%] pc:text-2lg">
           {info.title}
         </h3>
-        <p className="t-gray-500 mt-2 line-clamp-2 h-[48px] w-[80%] pc:-mt-[60px] pc:w-[60%] pc:text-lg">
+        <p className="mt-2 line-clamp-2 h-[48px] w-[80%] text-md text-gray-500 pc:-mt-[60px] pc:w-[60%] pc:text-lg">
           {info.content}
         </p>
         <div className="absolute right-3 top-3 pc:right-6 pc:top-6">


### PR DESCRIPTION
## 🧩 이슈 번호 #372 

## 🔎 작업 내용
알바토크페이지의 게시글에 썸네일을 추가했습니다.
제목과 본문이 길어질 때 '...' 으로 축약되도록 수정하였습니다.

## 이미지 첨부

![screencapture-localhost-3000-albatalk-2024-12-25-14_39_38](https://github.com/user-attachments/assets/484f7aae-2eea-47f4-a37e-bf01d7db6c5b)


## 👩‍💻 공유 포인트 및 논의 사항
