### PR TITLE
Fix:진행상태 변경 모달 로직 수정

### DIFF
--- a/src/components/modal/modalActions/selectProgressAction.ts
+++ b/src/components/modal/modalActions/selectProgressAction.ts
@@ -4,14 +4,14 @@ import instance from "@/lib/instance";
 import { ProgressValue } from "../modalContent/SelectProgressModal";
 
 export const selectProgressAction = async (
-  status: ProgressValue,
+  data: { status: ProgressValue },
   applicationId: number | null
 ) => {
   const response = await instance(
     `${process.env.NEXT_PUBLIC_API_URL}/applications/${applicationId}`,
     {
       method: "PATCH",
-      body: JSON.stringify(status),
+      body: JSON.stringify(data),
       headers: {
         "Content-Type": "application/json",
       },

--- a/src/components/modal/modalContent/SelectProgressModal.tsx
+++ b/src/components/modal/modalContent/SelectProgressModal.tsx
@@ -44,6 +44,7 @@ const SelectProgressModal = () => {
       if (response.status) {
         addToast("지원상태 수정이 완료되었습니다.", "success");
         closeModal();
+        window.location.reload();
       } else {
         console.error(response.message, response.status);
         addToast(response.message as string, "warning");

--- a/src/components/modal/modalContent/SelectProgressModal.tsx
+++ b/src/components/modal/modalContent/SelectProgressModal.tsx
@@ -7,8 +7,7 @@ import { useState } from "react";
 import { useModal } from "@/hooks/useModal";
 import { useToast } from "@/hooks/useToast";
 import { selectProgressAction } from "../modalActions/selectProgressAction";
-import { useAtomValue } from "jotai";
-import { applicationIdAtom } from "@/atoms/modalAtomStore";
+import { useParams } from "next/navigation";
 
 export type ProgressValue =
   | "REJECTED"
@@ -28,7 +27,8 @@ const SelectProgressModal = () => {
   const { addToast } = useToast();
   const viewPort = useViewPort();
   const [selected, setSelected] = useState<ProgressValue>("INTERVIEW_PENDING");
-  const applicationId = useAtomValue(applicationIdAtom);
+
+  const { applicationId } = useParams() as { applicationId: string };
 
   const handleChange = (value: ProgressValue) => {
     setSelected(value);
@@ -36,9 +36,12 @@ const SelectProgressModal = () => {
 
   const handleSubmit = async () => {
     try {
-      const response = await selectProgressAction(selected, applicationId);
+      const response = await selectProgressAction(
+        { status: selected },
+        Number(applicationId)
+      );
 
-      if (response.status === 200) {
+      if (response.status) {
         addToast("지원상태 수정이 완료되었습니다.", "success");
         closeModal();
       } else {


### PR DESCRIPTION
## 🧩 이슈 번호 #375 

## 🔎 작업 내용
진행 상태 변경 모달 로직을 수정하였습니다.
1. 데이터 패칭에 오류가 발생하였는데 보내주는 body값이 {status: body} 이렇게 보내줘야 했는데 body만 보내서 문제가 생겼었습니다.

2. 기존에는 applicationId를 전역상태로 관리하였는데 현재는 페이지에서 받아올수 있기 때문에
모달 내에서 useParams를 사용하여 applicationId를 받아올 수 있도록 변경하였습니다.

## 이미지 첨부

https://github.com/user-attachments/assets/d294da19-d296-4bda-ac45-491845f6935e



## 👩‍💻 공유 포인트 및 논의 사항

모달로 진행상태를 변경하였을 때 페이지에서 즉각적으로 상태를 반영하기 위해
 window.location.reload(); 코드 사용
