### PR TITLE
Chore: 알바폼 수정하기 페이지 딜레이현상 완화

### DIFF
--- a/src/app/addform/components/StepContainer.tsx
+++ b/src/app/addform/components/StepContainer.tsx
@@ -44,19 +44,20 @@ const StepContainer = ({ albaForm, formId }: StepContainerProps) => {
   const isEdit = albaForm && !("status" in albaForm);
   const { initializeAddForm } = useAddFormInit({ albaForm });
 
-  // 수정하기 마운트 시 초기화
+  // 수정하기 마운트 시 초기화, 만들기페이지에서 마운트 시 전체 임시저장 데이터 가져오기
   useEffect(() => {
     if (isEdit) {
       initializeAddForm(methods, setCurrentImageList);
+      return;
     }
-  }, [isEdit, initializeAddForm, methods, setCurrentImageList]);
-
-  // 마운트 시 전체 임시저장 데이터 가져오기
-  useEffect(() => {
-    if (!isEdit) {
-      loadAllTempData();
-    }
-  }, [loadAllTempData, isEdit]);
+    loadAllTempData();
+  }, [
+    isEdit,
+    initializeAddForm,
+    methods,
+    setCurrentImageList,
+    loadAllTempData,
+  ]);
 
   // 새로 쓰기 버튼 클릭 시 전체 임시저장 데이터 초기화
   useEffect(() => {

--- a/src/app/addform/components/StepOneContents.tsx
+++ b/src/app/addform/components/StepOneContents.tsx
@@ -33,10 +33,11 @@ const StepOneContents = ({ isEdit }: { isEdit: boolean | undefined }) => {
     currentImageList,
     temporaryDateRange,
     setTemporaryDataByStep,
+    isEdit,
   });
 
   // 1단계 '작성중' 태그 여부
-  useStepOneActive({ fields, setStepOneActive });
+  useStepOneActive({ fields, setStepOneActive, isEdit });
 
   // 추출한 필수값을 폼에 적용
   useEffect(() => {

--- a/src/app/addform/components/StepTwoContents.tsx
+++ b/src/app/addform/components/StepTwoContents.tsx
@@ -51,6 +51,8 @@ const StepTwoContents = ({ isEdit }: { isEdit: boolean | undefined }) => {
 
   // 2단계 '작성중' 태그 여부
   useEffect(() => {
+    if (isEdit) return;
+
     const subscription = watch((value, { name }) => {
       if (name && fields.includes(name as (typeof fields)[number])) {
         const currentValue = value[name as keyof typeof value];
@@ -61,7 +63,7 @@ const StepTwoContents = ({ isEdit }: { isEdit: boolean | undefined }) => {
     });
 
     return () => subscription.unsubscribe();
-  }, [watch, fields, setStepActive]);
+  }, [watch, fields, setStepActive, isEdit]);
 
   // 추출한 필수값을 폼에 적용
   useEffect(() => {

--- a/src/hooks/useAddFormStepOne.ts
+++ b/src/hooks/useAddFormStepOne.ts
@@ -22,11 +22,12 @@ export const useAddFormStepOne = () => {
   );
 
   const stepOneData = useMemo(() => {
+    const currentValues = getValues();
     return fields.reduce(
-      (acc, field) => ({ ...acc, [field]: watch(field) }),
+      (acc, field) => ({ ...acc, [field]: currentValues[field] }),
       {} as NonNullable<AddFormStepProps["stepOne"]>
     );
-  }, [watch, fields]);
+  }, [getValues, fields]);
 
   return { watch, setValue, getValues, stepOneData, fields };
 };
@@ -36,15 +37,18 @@ export const useStepOneTemporaryData = ({
   currentImageList,
   temporaryDateRange,
   setTemporaryDataByStep,
+  isEdit,
 }: {
   currentImageList: File[];
   temporaryDateRange: [string, string];
   setTemporaryDataByStep: (data: AddFormStepProps) => void;
+  isEdit?: boolean;
 }) => {
   const { getValues } = useFormContext<z.infer<typeof addFormSchema>>();
 
   // 임시 데이터 atom 업데이트
   useEffect(() => {
+    if (isEdit) return;
     const title = getValues("title");
     const description = getValues("description");
 
@@ -67,7 +71,13 @@ export const useStepOneTemporaryData = ({
     };
 
     updateTemporaryData();
-  }, [getValues, setTemporaryDataByStep, currentImageList, temporaryDateRange]);
+  }, [
+    getValues,
+    setTemporaryDataByStep,
+    currentImageList,
+    temporaryDateRange,
+    isEdit,
+  ]);
 
   const loadFromLocalStorage = useCallback(() => {
     const localStorageData = localStorage.getItem("stepOne");
@@ -84,14 +94,18 @@ export const useStepOneTemporaryData = ({
 export const useStepOneActive = ({
   fields,
   setStepOneActive,
+  isEdit,
 }: {
   fields: readonly string[];
   setStepOneActive: (active: boolean) => void;
+  isEdit?: boolean;
 }) => {
   const { watch } = useFormContext<z.infer<typeof addFormSchema>>();
 
   // 1단계 '작성중' 태그 여부
   useEffect(() => {
+    if (isEdit) return;
+
     const subscription = watch((value, { name }) => {
       if (name && fields.includes(name as (typeof fields)[number])) {
         const currentValue = value[name as keyof typeof value];
@@ -102,5 +116,5 @@ export const useStepOneActive = ({
     });
 
     return () => subscription.unsubscribe();
-  }, [watch, fields, setStepOneActive]);
+  }, [watch, fields, setStepOneActive, isEdit]);
 };


### PR DESCRIPTION
## 🧩 이슈 번호 #382

## 🔎 작업 내용
<!-- - 기능에서 어떤 부분이 구현되었는지 설명해주세요. -->
- 알바폼 수정하기페이지를 들어가면 딜레이가 생기는데 이를 약간 완화했습니다.
- 완전히 제거하지는 못했습니다.

## 이미지 첨부
<!-- preview 이미지 혹 동영상을 첨부해주세요. -->
https://github.com/user-attachments/assets/52cfa22d-a013-45df-90fe-820225d4fd24

## 🔧 앞으로의 과제

<!-- - 이번 이슈에서 앞으로 남은 할 일을 적어주세요. -->
- 없음

## 👩‍💻 공유 포인트 및 논의 사항

<!-- 공유하거나 논의할 사항을 작성해주세요. -->
- 최적화 훅의 적절한 사용을 했는데도 완전 제거가 안되서 react-hook-form의 watch를 구독하는 부분이 늘어나면서 생긴건지 원인을 파악하는 중에 있습니다.
- 알바폼 만들기페이지와 내용의 유무만 차이날 뿐 다른 부분이 없는데 만들기페이지는 딜레이가 없어서 외부적인 요인 때문인지도 확인해봐야 할 것 같습니다.
