### PR TITLE
Chore: 재요청로직만 instance로 복귀

### DIFF
--- a/src/lib/instance.ts
+++ b/src/lib/instance.ts
@@ -25,6 +25,17 @@ const instance = async (url: string, options: RequestInit = {}) => {
         error: "장시간 사용하지 않아 로그인이 해제되었습니다.",
       };
     }
+
+    const newAccessToken = cookieStore.get("accessToken")?.value;
+
+    if (newAccessToken && newAccessToken !== accessToken) {
+      options.headers = {
+        ...options.headers,
+        Authorization: `Bearer ${newAccessToken}`,
+      };
+    }
+
+    response = await fetch(url, { ...options });
   }
 
   if (response.status === 204) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -31,17 +31,6 @@ export const middleware = async (request: NextRequest) => {
     if (response.ok) {
       const { accessToken } = await response.json();
       await createCookie({ name: "accessToken", value: accessToken });
-
-      const originalRequest = new Headers(request.headers);
-      originalRequest.set("Authorization", `Bearer ${accessToken}`);
-
-      const newRequest = new Request(request.url, {
-        method: request.method,
-        headers: originalRequest,
-        body: request.body,
-      });
-
-      return fetch(newRequest);
     }
   }
 


### PR DESCRIPTION
## 🧩 이슈 번호 #387

## 🔎 작업 내용
<!-- - 기능에서 어떤 부분이 구현되었는지 설명해주세요. -->
- 새 액세스토큰 발급 후 재요청로직만 instance로 옮겼습니다.
- 이제 새 액세스토큰이 저장되면 문제없이 기존요청을 이어갈 수 있습니다.

## 이미지 첨부
<!-- preview 이미지 혹 동영상을 첨부해주세요. -->
https://github.com/user-attachments/assets/809ebc63-ca8e-4203-b373-968c48f82c97

## 🔧 앞으로의 과제

<!-- - 이번 이슈에서 앞으로 남은 할 일을 적어주세요. -->
- 없음

## 👩‍💻 공유 포인트 및 논의 사항

<!-- 공유하거나 논의할 사항을 작성해주세요. -->
- 기존에는 새 액세스토큰을 발급받아도 이후 기존요청이 처리가 안되는 현상이 있었습니다.
- 영상에서는 get요청을 테스트하여 새 액세스토큰을 받아오면 기존 get 요청이 이어지는 것을 확인하실 수 있습니다.
