### PR TITLE
Chore: 알바폼만들기 및 수정하기 이미지 무한루프 수정

### DIFF
--- a/src/components/button/ImageInput.tsx
+++ b/src/components/button/ImageInput.tsx
@@ -30,6 +30,8 @@ const ImageInput = ({
   const [error, setError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const MAX_FILE_SIZE_MB = 5;
+  const selectedImagesRef = useRef(selectedImages);
+  selectedImagesRef.current = selectedImages;
 
   // 크기별 클래스
   const sizeClasses = {
@@ -41,14 +43,13 @@ const ImageInput = ({
   // 임시저장 이미지가 있을 시 이를 감지하여 미리보기 이미지 표출
   useEffect(() => {
     if (initialImage?.length) {
-      selectedImages.forEach((url) => URL.revokeObjectURL(url));
+      selectedImagesRef.current.forEach((url) => URL.revokeObjectURL(url));
 
-      setSelectedImages(
-        initialImage.map((image) => URL.createObjectURL(image))
-      );
+      const newImages = initialImage.map((img) => URL.createObjectURL(img));
+      setSelectedImages(newImages);
       setNewFiles(initialImage);
     }
-  }, [initialImage, selectedImages]);
+  }, [initialImage]);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## 🧩 이슈 번호 #409

## 🔎 작업 내용
<!-- - 기능에서 어떤 부분이 구현되었는지 설명해주세요. -->
- 최종배포 이후 생긴 이미지 무한루프 현상을 수정했습니다.

## 이미지 첨부
<!-- preview 이미지 혹 동영상을 첨부해주세요. -->
https://github.com/user-attachments/assets/cc879356-d1ca-482f-a427-3216db286dbc

## 🔧 앞으로의 과제

<!-- - 이번 이슈에서 앞으로 남은 할 일을 적어주세요. -->
- 없음

## 👩‍💻 공유 포인트 및 논의 사항

<!-- 공유하거나 논의할 사항을 작성해주세요. -->
- ImageInput의 원인 코드를 수정했습니다.
- 첫 useEffect에서 의존성배열에 selectedImages가 포함된 게 원인이었는데, 생략하면 eslint 경고가 떠서 아래와 같은 코드를 추가했습니다.
```
const selectedImagesRef = useRef(selectedImages);
selectedImagesRef.current = selectedImages;

useEffect(() => {
    if (initialImage?.length) {
      selectedImagesRef.current.forEach((url) => URL.revokeObjectURL(url));

      const newImages = initialImage.map((img) => URL.createObjectURL(img));
      setSelectedImages(newImages);
      setNewFiles(initialImage);
    }
  }, [initialImage]);
```

